### PR TITLE
feat(reward): Differential Sharpe Ratio reward mode (closes #2)

### DIFF
--- a/scripts/compare_rewards.py
+++ b/scripts/compare_rewards.py
@@ -26,7 +26,7 @@ from pathlib import Path
 _root = Path(__file__).resolve().parent.parent
 PYTHON = sys.executable
 
-REWARD_TYPES = ("return", "sharpe", "sortino", "mean_variance")
+REWARD_TYPES = ("return", "sharpe", "sortino", "mean_variance", "differential_sharpe")
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -197,9 +197,15 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     # PortfolioWeight env extras
     parser.add_argument(
         "--reward-type",
-        choices=["return", "sharpe", "sortino", "mean_variance"],
+        choices=["return", "sharpe", "sortino", "mean_variance", "differential_sharpe"],
         default="return",
         help="Reward type (portfolio_weight env only, default return)",
+    )
+    parser.add_argument(
+        "--dsr-eta",
+        type=float,
+        default=0.05,
+        help="Differential Sharpe Ratio decay rate (differential_sharpe reward only, default 0.05)",
     )
     parser.add_argument(
         "--max-position-pct",
@@ -466,6 +472,7 @@ def make_env(
                 forward_period=args.forward_period,
                 reward_type=args.reward_type,
                 risk_aversion=args.risk_aversion,
+                dsr_eta=args.dsr_eta,
                 cost_bps=args.cost_bps,
                 max_position_pct=args.max_position_pct,
                 max_industry_pct=args.max_industry_pct,

--- a/src/aurumq_rl/portfolio_weight_env.py
+++ b/src/aurumq_rl/portfolio_weight_env.py
@@ -8,10 +8,11 @@ Difference vs StockPickingEnv
 
 Reward types
 ------------
-* return        — simple forward return
-* sharpe        — rolling Sharpe ratio
-* sortino       — rolling Sortino ratio
-* mean_variance — Markowitz mean - λ * variance
+* return              — simple forward return
+* sharpe              — rolling Sharpe ratio
+* sortino             — rolling Sortino ratio
+* mean_variance       — Markowitz mean - λ * variance
+* differential_sharpe — recurrent per-step Sharpe increment (Moody & Saffell 1998)
 
 State
 -----
@@ -47,6 +48,8 @@ from aurumq_rl.env import (
     _apply_trading_mask,
 )
 from aurumq_rl.reward_functions import (
+    DEFAULT_DSR_ETA,
+    DifferentialSharpe,
     mean_variance_reward,
     sharpe_reward,
     sortino_reward,
@@ -57,6 +60,8 @@ DEFAULT_MAX_POSITION_PCT: float = 0.05
 DEFAULT_MAX_INDUSTRY_PCT: float = 0.30
 _SOFTMAX_TEMP: float = 1.0
 _MIN_WEIGHT_SUM: float = 1e-8
+
+_REWARD_TYPES = ("return", "sharpe", "sortino", "mean_variance", "differential_sharpe")
 
 
 @dataclass(frozen=True)
@@ -70,10 +75,13 @@ class PortfolioWeightConfig:
     max_industry_pct: float = DEFAULT_MAX_INDUSTRY_PCT
     rolling_window: int = 20
     forward_period: int = 10
-    reward_type: Literal["return", "sharpe", "sortino", "mean_variance"] = "sharpe"
+    reward_type: Literal["return", "sharpe", "sortino", "mean_variance", "differential_sharpe"] = (
+        "sharpe"
+    )
     risk_aversion: float = 1.0
     cost_bps: float = 30.0
     turnover_penalty: float = 0.001
+    dsr_eta: float = DEFAULT_DSR_ETA
 
     def __post_init__(self) -> None:
         if self.start_date >= self.end_date:
@@ -88,12 +96,14 @@ class PortfolioWeightConfig:
             raise ValueError(f"max_position_pct={self.max_position_pct} must be in (0, 1]")
         if not 0.0 < self.max_industry_pct <= 1.0:
             raise ValueError(f"max_industry_pct={self.max_industry_pct} must be in (0, 1]")
-        if self.reward_type not in {"return", "sharpe", "sortino", "mean_variance"}:
+        if self.reward_type not in _REWARD_TYPES:
             raise ValueError(f"reward_type={self.reward_type!r} not supported")
         if self.risk_aversion < 0.0:
             raise ValueError(f"risk_aversion={self.risk_aversion} must be >= 0")
         if self.rolling_window < 1:
             raise ValueError(f"rolling_window={self.rolling_window} must be >= 1")
+        if not 0.0 < self.dsr_eta <= 1.0:
+            raise ValueError(f"dsr_eta={self.dsr_eta} must be in (0, 1]")
 
 
 def _project_weights(
@@ -276,6 +286,7 @@ if GYM_AVAILABLE:
             self._returns_history: list[np.ndarray] = []
             self._cumulative_reward: float = 0.0
             self._episode_rewards: list[float] = []
+            self._dsr = DifferentialSharpe(eta=config.dsr_eta)
 
         def reset(
             self,
@@ -290,6 +301,7 @@ if GYM_AVAILABLE:
             self._returns_history = []
             self._cumulative_reward = 0.0
             self._episode_rewards = []
+            self._dsr.reset()
 
             obs = self._get_obs(0)
             info = {"step": 0, "n_stocks": self.n_stocks, "n_factors": self.n_factors}
@@ -395,6 +407,12 @@ if GYM_AVAILABLE:
 
             if rtype == "return":
                 return float(np.dot(weights, masked_returns))
+
+            if rtype == "differential_sharpe":
+                # Same realized per-step portfolio return the rolling
+                # sharpe/sortino modes consume, so the modes stay comparable.
+                realized_return = float(np.dot(weights, masked_returns))
+                return self._dsr.update(realized_return)
 
             wh = np.array(self._weights_history, dtype=np.float64)
             rh = np.array(self._returns_history, dtype=np.float64)

--- a/src/aurumq_rl/reward_functions.py
+++ b/src/aurumq_rl/reward_functions.py
@@ -1,10 +1,11 @@
 """RL reward function library.
 
-Four reward types:
-  return        — simple forward return
-  sharpe        — rolling Sharpe ratio
-  sortino       — rolling Sortino ratio
-  mean_variance — Markowitz mean - λ * variance
+Five reward types:
+  return              — simple forward return
+  sharpe              — rolling Sharpe ratio
+  sortino             — rolling Sortino ratio
+  mean_variance       — Markowitz mean - λ * variance
+  differential_sharpe — recurrent per-step Sharpe increment (Moody & Saffell 1998)
 """
 
 from __future__ import annotations
@@ -22,6 +23,12 @@ VOLATILITY_FLOOR: float = 1e-4
 
 # Trading-day annualization factor
 ANNUALIZATION_FACTOR: float = 252.0
+
+# Default DSR decay rate eta = 1 / rolling_window (default rolling_window=20
+# in PortfolioWeightConfig), so the exponential moving average's effective
+# memory span matches the rolling Sharpe/Sortino window — keeps the modes
+# comparable when swapping reward_type without retuning anything else.
+DEFAULT_DSR_ETA: float = 0.05
 
 
 def _portfolio_return_series(
@@ -174,10 +181,98 @@ def mean_variance_reward(
     return expected_return - risk_aversion * portfolio_variance
 
 
+class DifferentialSharpe:
+    """Stateful Differential Sharpe Ratio (Moody & Saffell 1998).
+
+    A recurrent, O(1)-per-step alternative to windowed ``sharpe_reward`` /
+    ``sortino_reward``. Instead of a rolling-window Sharpe snapshot (which,
+    summed over steps, optimizes neither Sharpe nor return — the C5 issue),
+    DSR gives the per-step *marginal contribution* to the Sharpe ratio,
+    tracked via exponentially-decayed moving averages of the return (``A``)
+    and squared return (``B``):
+
+        dA = R_t - A_{t-1}
+        dB = R_t^2 - B_{t-1}
+        DSR_t = (B_{t-1} * dA - 0.5 * A_{t-1} * dB) / (B_{t-1} - A_{t-1}^2)^1.5
+        A_t = A_{t-1} + eta * dA
+        B_t = B_{t-1} + eta * dB
+
+    Summing DSR_t over an episode approximates the change in the batch
+    Sharpe ratio (Moody & Saffell, "Reinforcement Learning for Trading",
+    NeurIPS 1998), so maximizing cumulative DSR reward directly targets
+    end-of-episode Sharpe.
+
+    Numerical guards mirror sharpe_reward/sortino_reward's C5 fix exactly:
+    (a) warm-up — fewer than MIN_RISK_WINDOW updates observed (A/B have not
+    stabilized) — returns neutral 0.0; (b) past warm-up, the variance
+    B - A^2 denominator is floored at VOLATILITY_FLOOR^2 (never gated to a
+    hard 0.0), so a degenerate/near-constant return stream yields a bounded
+    finite value instead of a division-by-near-zero spike — the same
+    floor-the-denominator strategy sharpe_reward/sortino_reward use, rather
+    than a separate variance-based zero-gate (which would still let a
+    transient "phantom variance" hump from the zero-initialized EMA escape
+    unbounded for a genuinely constant stream near the guard boundary).
+    """
+
+    def __init__(self, eta: float = DEFAULT_DSR_ETA) -> None:
+        """Create a DSR tracker.
+
+        Parameters
+        ----------
+        eta : float
+            Decay / adaptation rate for the moving averages of R and R^2,
+            in (0, 1]. Larger eta adapts faster but is noisier; smaller eta
+            is smoother but slower to reflect regime changes. Default
+            ``DEFAULT_DSR_ETA`` (1/20, matching the rolling-mode default
+            window).
+        """
+        if not 0.0 < eta <= 1.0:
+            raise ValueError(f"eta={eta} must be in (0, 1]")
+        self.eta = eta
+        self.a: float = 0.0
+        self.b: float = 0.0
+        self._n: int = 0
+
+    def reset(self) -> None:
+        """Reset A, B, and the warm-up counter to their initial state."""
+        self.a = 0.0
+        self.b = 0.0
+        self._n = 0
+
+    def update(self, r: float) -> float:
+        """Consume one step's realized return and return this step's DSR.
+
+        Parameters
+        ----------
+        r : float
+            Realized portfolio return for this step (same quantity fed to
+            sharpe_reward/sortino_reward's per-step return series).
+        """
+        a_prev, b_prev = self.a, self.b
+        d_a = r - a_prev
+        d_b = r * r - b_prev
+        self._n += 1
+
+        if self._n <= MIN_RISK_WINDOW:
+            dsr = 0.0  # warm-up: A/B have not accumulated enough history
+        else:
+            variance = b_prev - a_prev * a_prev
+            # Floor (not zero-gate) the denominator: identical strategy to
+            # sharpe_reward/sortino_reward's max(sigma, VOLATILITY_FLOOR).
+            denom = max(variance, VOLATILITY_FLOOR**2) ** 1.5
+            dsr = (b_prev * d_a - 0.5 * a_prev * d_b) / denom
+
+        self.a = a_prev + self.eta * d_a
+        self.b = b_prev + self.eta * d_b
+        return float(dsr)
+
+
 __all__ = [
     "ANNUALIZATION_FACTOR",
+    "DEFAULT_DSR_ETA",
     "MIN_RISK_WINDOW",
     "VOLATILITY_FLOOR",
+    "DifferentialSharpe",
     "simple_return_reward",
     "sharpe_reward",
     "sortino_reward",

--- a/src/aurumq_rl/reward_functions.py
+++ b/src/aurumq_rl/reward_functions.py
@@ -202,16 +202,31 @@ class DifferentialSharpe:
     NeurIPS 1998), so maximizing cumulative DSR reward directly targets
     end-of-episode Sharpe.
 
-    Numerical guards mirror sharpe_reward/sortino_reward's C5 fix exactly:
-    (a) warm-up — fewer than MIN_RISK_WINDOW updates observed (A/B have not
-    stabilized) — returns neutral 0.0; (b) past warm-up, the variance
-    B - A^2 denominator is floored at VOLATILITY_FLOOR^2 (never gated to a
-    hard 0.0), so a degenerate/near-constant return stream yields a bounded
-    finite value instead of a division-by-near-zero spike — the same
-    floor-the-denominator strategy sharpe_reward/sortino_reward use, rather
-    than a separate variance-based zero-gate (which would still let a
-    transient "phantom variance" hump from the zero-initialized EMA escape
-    unbounded for a genuinely constant stream near the guard boundary).
+    Numerical safety (the whole point vs. the C5 spike):
+
+    * **Warm-starting A, B from the first observation** (``A_1 = R_1``,
+      ``B_1 = R_1^2``; the seeding step itself returns 0.0). This is the
+      standard EMA cold-start-bias fix, and it is what keeps DSR bounded on
+      a constant stream. Zero-initializing A, B instead (the naive choice)
+      makes the EMA-estimated variance ``B - A^2`` decay from its cold-start
+      value; on a constant-return stream it crosses VOLATILITY_FLOOR^2 mid-
+      trajectory (≈ step 179 at eta=0.05), and right there |DSR| peaks at
+      ≈ 0.5 * |R| / VOLATILITY_FLOOR — a *transient* spike that scales
+      LINEARLY with |R| (~49 at R=1%, but ~990 at R=20%, exceeding 1e3 at
+      A-share limit-up magnitudes). Flooring the denominator does NOT remove
+      this peak (it occurs while the apparent variance is above the floor).
+      Warm-starting does: a constant stream then has ``A = R``, ``B = R^2``
+      exactly from step 1, so every ``dA = dB = 0`` → numerator is exactly
+      0 → DSR is exactly 0.0 forever, at ANY magnitude, with no transient.
+    * **MIN_RISK_WINDOW warm-up gate**: the first MIN_RISK_WINDOW updates
+      return 0.0 (A/B have not accumulated enough history), mirroring
+      sharpe_reward/sortino_reward.
+    * **VOLATILITY_FLOOR on the denominator**: floors the variance^1.5 term
+      so an exactly-constant stream yields 0 / floor = 0.0 instead of a
+      0 / 0 NaN, and a genuinely near-degenerate window stays finite —
+      the same max(..., VOLATILITY_FLOOR) guard sharpe_reward/sortino_reward
+      use. With warm-starting this floor is a belt-and-braces guard, not the
+      primary defence (which is the warm-start itself).
     """
 
     def __init__(self, eta: float = DEFAULT_DSR_ETA) -> None:
@@ -248,17 +263,28 @@ class DifferentialSharpe:
             Realized portfolio return for this step (same quantity fed to
             sharpe_reward/sortino_reward's per-step return series).
         """
+        self._n += 1
+
+        # Warm-start: seed A, B from the first observation instead of from
+        # zero. Avoids the cold-start-bias transient that would otherwise
+        # spike |DSR| ≈ 0.5*|R|/VOLATILITY_FLOOR mid-trajectory on a
+        # constant stream (see class docstring). The seeding step emits 0.0.
+        if self._n == 1:
+            self.a = r
+            self.b = r * r
+            return 0.0
+
         a_prev, b_prev = self.a, self.b
         d_a = r - a_prev
         d_b = r * r - b_prev
-        self._n += 1
 
         if self._n <= MIN_RISK_WINDOW:
             dsr = 0.0  # warm-up: A/B have not accumulated enough history
         else:
             variance = b_prev - a_prev * a_prev
-            # Floor (not zero-gate) the denominator: identical strategy to
-            # sharpe_reward/sortino_reward's max(sigma, VOLATILITY_FLOOR).
+            # Floor the denominator so an exactly-constant stream gives
+            # 0 / floor = 0.0 rather than a 0 / 0 NaN. With warm-starting
+            # this is a belt-and-braces guard, not the primary defence.
             denom = max(variance, VOLATILITY_FLOOR**2) ** 1.5
             dsr = (b_prev * d_a - 0.5 * a_prev * d_b) / denom
 

--- a/tests/test_reward_functions.py
+++ b/tests/test_reward_functions.py
@@ -258,11 +258,12 @@ _DSR_RETURNS = [0.01, -0.02, 0.015, 0.03, -0.01, 0.02, 0.005, -0.015]
 def test_differential_sharpe_matches_hand_computed_recurrence() -> None:
     """DSR.update reproduces the Moody & Saffell recurrence for post-warm-up steps.
 
-    A_t, B_t evolve every step regardless of the warm-up gate; only the
-    *returned* reward is gated. We recompute the recurrence independently in
-    the test and compare against DifferentialSharpe's output for the steps
-    past MIN_RISK_WINDOW, where the guard is inactive and the raw formula
-    applies.
+    The first update warm-starts A, B from the seeding observation
+    (``A_1 = R_1``, ``B_1 = R_1^2``) and returns 0.0; thereafter A_t, B_t
+    evolve via the EMA recurrence every step, but only the reward past the
+    MIN_RISK_WINDOW gate is compared here (that is where the raw formula
+    applies). We recompute the recurrence — with the same warm-start
+    seeding — independently in the test.
     """
     eta = 0.05
     dsr = DifferentialSharpe(eta=eta)
@@ -271,9 +272,14 @@ def test_differential_sharpe_matches_hand_computed_recurrence() -> None:
     a, b = 0.0, 0.0
     expected: list[float] = []
     for i, r in enumerate(_DSR_RETURNS):
+        n = i + 1
+        if n == 1:  # warm-start seeding step: emit 0.0, seed A/B, no EMA step
+            expected.append(0.0)
+            a, b = r, r * r
+            continue
         d_a = r - a
         d_b = r * r - b
-        if i + 1 <= MIN_RISK_WINDOW:
+        if n <= MIN_RISK_WINDOW:
             expected.append(0.0)
         else:
             variance = b - a * a
@@ -285,13 +291,13 @@ def test_differential_sharpe_matches_hand_computed_recurrence() -> None:
     for i in range(MIN_RISK_WINDOW, len(_DSR_RETURNS)):
         assert actual[i] == pytest.approx(expected[i])
     # Pinned reference values (guards against silent formula drift).
-    assert actual[5] == pytest.approx(1.9040749737866718, rel=1e-6)
-    assert actual[6] == pytest.approx(0.4046549824137689, rel=1e-6)
-    assert actual[7] == pytest.approx(-2.144393833232199, rel=1e-6)
+    assert actual[5] == pytest.approx(0.9626651786208611, rel=1e-6)
+    assert actual[6] == pytest.approx(-0.10059759195011124, rel=1e-6)
+    assert actual[7] == pytest.approx(-6.292455580242512, rel=1e-6)
 
 
 def test_differential_sharpe_single_sample_returns_zero() -> None:
-    """First update (A=B=0 history) is degenerate → neutral 0.0, not a spike."""
+    """The seeding update returns 0.0 (no DSR on the warm-start sample)."""
     dsr = DifferentialSharpe()
     assert dsr.update(0.05) == 0.0
 
@@ -302,22 +308,28 @@ def test_differential_sharpe_warmup_below_min_risk_window_returns_zero() -> None
         assert dsr.update(0.01) == 0.0
 
 
-def test_differential_sharpe_constant_stream_bounded_by_variance_floor() -> None:
+@pytest.mark.parametrize("r", [0.01, 0.20, -0.20, 0.44])
+def test_differential_sharpe_constant_stream_stays_zero_at_any_magnitude(r: float) -> None:
     """Pathological all-equal return stream: true variance is 0 throughout.
 
     This is the C5 failure class (mu / near-zero-sigma spike) applied to the
-    recurrent DSR form. Mirroring sharpe_reward/sortino_reward's own
-    zero-variance-window test (test_sharpe_zero_variance_window_bounded_by_floor,
-    which floors to a finite nonzero value rather than forcing exactly 0.0),
-    DSR must stay finite and bounded (never a >1e3 C5-class spike) even
-    though the zero-initialized EMA has a transient "phantom variance" hump
-    before settling — it must never diverge like the pre-fix mu/1e-8 case.
+    recurrent DSR form. The warm-start (A=R, B=R^2 from the seeding step)
+    makes every subsequent dA = dB = 0, so DSR is *exactly* 0.0 forever — at
+    ANY magnitude, including A-share limit-up levels (±20%, and the ±44%
+    first-day-after-IPO / ST-band extremes).
+
+    Regression guard: the earlier zero-initialized-EMA implementation left a
+    phantom-variance transient whose peak |DSR| ≈ 0.5*|R|/VOLATILITY_FLOOR
+    scaled LINEARLY with |R| — ≈49 at R=1% but ≈990 at R=20% and >1e3 above,
+    which is exactly the C5-class spike this reward mode exists to avoid. The
+    r=0.20 case below is the one that would have caught it; it is well under
+    1.0 (in fact exactly 0.0) now.
     """
     dsr = DifferentialSharpe()
-    values = [dsr.update(0.01) for _ in range(500)]
-    assert all(v == 0.0 for v in values[:MIN_RISK_WINDOW])  # warm-up
+    values = [dsr.update(r) for _ in range(400)]
     assert all(np.isfinite(v) for v in values)
-    assert max(abs(v) for v in values) < 1e3
+    assert all(v == 0.0 for v in values)  # exact 0.0, no transient
+    assert max(abs(v) for v in values) < 1.0
 
 
 def test_differential_sharpe_varying_stream_is_finite_and_bounded() -> None:
@@ -331,21 +343,37 @@ def test_differential_sharpe_varying_stream_is_finite_and_bounded() -> None:
 
 
 def test_differential_sharpe_cumulative_sum_tracks_sharpe_direction() -> None:
-    """sum(DSR_t) is positive for a stream with a good risk-adjusted profile
-    and negative for a symmetric bad one — the algorithmic justification for
-    using DSR as a per-step reward instead of a rolling Sharpe snapshot.
+    """sum(DSR_t) tracks the *change* in the batch Sharpe ratio — the
+    algorithmic justification for DSR as a per-step reward instead of a
+    rolling-Sharpe snapshot.
+
+    The correct property is about Sharpe *change*, not level: a stream whose
+    risk-adjusted profile IMPROVES over the episode (a poor first half, a
+    strong second half) has a positive cumulative DSR; one that DEGRADES
+    (strong then poor) has a negative one. (A stationary stream, by contrast,
+    has no Sharpe change and a cumulative DSR of ~0 ± noise — which is why an
+    earlier version of this test, asserting the sign of a *stationary* good vs
+    bad stream, was actually measuring a zero-init cold-start artifact rather
+    than the real property; warm-starting removes that artifact.)
+
+    Aggregated over a seed ensemble to stay robust, not brittle.
     """
-    rng = np.random.default_rng(7)
-    good = rng.normal(0.01, 0.01, 80)
-    bad = rng.normal(-0.01, 0.01, 80)
+    improving_sums = []
+    degrading_sums = []
+    for seed in range(30):
+        rng = np.random.default_rng(seed)
+        improving = np.concatenate([rng.normal(-0.01, 0.01, 100), rng.normal(0.01, 0.01, 100)])
+        rng2 = np.random.default_rng(1000 + seed)
+        degrading = np.concatenate([rng2.normal(0.01, 0.01, 100), rng2.normal(-0.01, 0.01, 100)])
+        d_imp = DifferentialSharpe(eta=0.05)
+        d_deg = DifferentialSharpe(eta=0.05)
+        improving_sums.append(sum(d_imp.update(float(r)) for r in improving))
+        degrading_sums.append(sum(d_deg.update(float(r)) for r in degrading))
 
-    dsr_good = DifferentialSharpe(eta=0.05)
-    dsr_bad = DifferentialSharpe(eta=0.05)
-    sum_good = sum(dsr_good.update(float(r)) for r in good)
-    sum_bad = sum(dsr_bad.update(float(r)) for r in bad)
-
-    assert sum_good > 0
-    assert sum_bad < 0
+    # Aggregate sign is unambiguous (improving positive, degrading negative).
+    assert float(np.sum(improving_sums)) > 0
+    assert float(np.sum(degrading_sums)) < 0
+    assert float(np.mean(improving_sums)) > float(np.mean(degrading_sums))
 
 
 def test_differential_sharpe_reset_clears_state() -> None:

--- a/tests/test_reward_functions.py
+++ b/tests/test_reward_functions.py
@@ -9,6 +9,7 @@ from aurumq_rl.reward_functions import (
     ANNUALIZATION_FACTOR,
     MIN_RISK_WINDOW,
     VOLATILITY_FLOOR,
+    DifferentialSharpe,
     mean_variance_reward,
     sharpe_reward,
     simple_return_reward,
@@ -245,3 +246,175 @@ def test_mean_variance_invalid_dims() -> None:
             weights=np.zeros(2),
             return_panel=np.zeros(10),  # 1D not allowed
         )
+
+
+# ---------------------------------------------------------------------------
+# DifferentialSharpe (Moody & Saffell 1998) — issue #2
+# ---------------------------------------------------------------------------
+
+_DSR_RETURNS = [0.01, -0.02, 0.015, 0.03, -0.01, 0.02, 0.005, -0.015]
+
+
+def test_differential_sharpe_matches_hand_computed_recurrence() -> None:
+    """DSR.update reproduces the Moody & Saffell recurrence for post-warm-up steps.
+
+    A_t, B_t evolve every step regardless of the warm-up gate; only the
+    *returned* reward is gated. We recompute the recurrence independently in
+    the test and compare against DifferentialSharpe's output for the steps
+    past MIN_RISK_WINDOW, where the guard is inactive and the raw formula
+    applies.
+    """
+    eta = 0.05
+    dsr = DifferentialSharpe(eta=eta)
+    actual = [dsr.update(r) for r in _DSR_RETURNS]
+
+    a, b = 0.0, 0.0
+    expected: list[float] = []
+    for i, r in enumerate(_DSR_RETURNS):
+        d_a = r - a
+        d_b = r * r - b
+        if i + 1 <= MIN_RISK_WINDOW:
+            expected.append(0.0)
+        else:
+            variance = b - a * a
+            denom = max(variance, VOLATILITY_FLOOR**2) ** 1.5
+            expected.append((b * d_a - 0.5 * a * d_b) / denom)
+        a = a + eta * d_a
+        b = b + eta * d_b
+
+    for i in range(MIN_RISK_WINDOW, len(_DSR_RETURNS)):
+        assert actual[i] == pytest.approx(expected[i])
+    # Pinned reference values (guards against silent formula drift).
+    assert actual[5] == pytest.approx(1.9040749737866718, rel=1e-6)
+    assert actual[6] == pytest.approx(0.4046549824137689, rel=1e-6)
+    assert actual[7] == pytest.approx(-2.144393833232199, rel=1e-6)
+
+
+def test_differential_sharpe_single_sample_returns_zero() -> None:
+    """First update (A=B=0 history) is degenerate → neutral 0.0, not a spike."""
+    dsr = DifferentialSharpe()
+    assert dsr.update(0.05) == 0.0
+
+
+def test_differential_sharpe_warmup_below_min_risk_window_returns_zero() -> None:
+    dsr = DifferentialSharpe()
+    for _ in range(MIN_RISK_WINDOW):
+        assert dsr.update(0.01) == 0.0
+
+
+def test_differential_sharpe_constant_stream_bounded_by_variance_floor() -> None:
+    """Pathological all-equal return stream: true variance is 0 throughout.
+
+    This is the C5 failure class (mu / near-zero-sigma spike) applied to the
+    recurrent DSR form. Mirroring sharpe_reward/sortino_reward's own
+    zero-variance-window test (test_sharpe_zero_variance_window_bounded_by_floor,
+    which floors to a finite nonzero value rather than forcing exactly 0.0),
+    DSR must stay finite and bounded (never a >1e3 C5-class spike) even
+    though the zero-initialized EMA has a transient "phantom variance" hump
+    before settling — it must never diverge like the pre-fix mu/1e-8 case.
+    """
+    dsr = DifferentialSharpe()
+    values = [dsr.update(0.01) for _ in range(500)]
+    assert all(v == 0.0 for v in values[:MIN_RISK_WINDOW])  # warm-up
+    assert all(np.isfinite(v) for v in values)
+    assert max(abs(v) for v in values) < 1e3
+
+
+def test_differential_sharpe_varying_stream_is_finite_and_bounded() -> None:
+    """A genuinely varying stream produces finite, O(1)-magnitude DSR values."""
+    rng = np.random.default_rng(3)
+    returns = rng.standard_normal(300) * 0.01
+    dsr = DifferentialSharpe()
+    values = [dsr.update(float(r)) for r in returns]
+    assert all(np.isfinite(v) for v in values)
+    assert max(abs(v) for v in values) < 1e3
+
+
+def test_differential_sharpe_cumulative_sum_tracks_sharpe_direction() -> None:
+    """sum(DSR_t) is positive for a stream with a good risk-adjusted profile
+    and negative for a symmetric bad one — the algorithmic justification for
+    using DSR as a per-step reward instead of a rolling Sharpe snapshot.
+    """
+    rng = np.random.default_rng(7)
+    good = rng.normal(0.01, 0.01, 80)
+    bad = rng.normal(-0.01, 0.01, 80)
+
+    dsr_good = DifferentialSharpe(eta=0.05)
+    dsr_bad = DifferentialSharpe(eta=0.05)
+    sum_good = sum(dsr_good.update(float(r)) for r in good)
+    sum_bad = sum(dsr_bad.update(float(r)) for r in bad)
+
+    assert sum_good > 0
+    assert sum_bad < 0
+
+
+def test_differential_sharpe_reset_clears_state() -> None:
+    dsr = DifferentialSharpe(eta=0.1)
+    for r in _DSR_RETURNS:
+        dsr.update(r)
+    assert dsr.a != 0.0 or dsr.b != 0.0
+
+    dsr.reset()
+    assert dsr.a == 0.0
+    assert dsr.b == 0.0
+
+    # A fresh instance and a reset instance must behave identically going
+    # forward — no leakage of the prior episode's A/B into the next one.
+    fresh = DifferentialSharpe(eta=0.1)
+    for r in _DSR_RETURNS:
+        assert dsr.update(r) == pytest.approx(fresh.update(r))
+
+
+def test_differential_sharpe_invalid_eta_raises() -> None:
+    with pytest.raises(ValueError):
+        DifferentialSharpe(eta=0.0)
+    with pytest.raises(ValueError):
+        DifferentialSharpe(eta=1.5)
+
+
+# ---------------------------------------------------------------------------
+# PortfolioWeightEnv wiring — "differential_sharpe" reward mode (issue #2)
+# ---------------------------------------------------------------------------
+
+
+def test_portfolio_weight_env_differential_sharpe_mode() -> None:
+    pytest.importorskip("gymnasium")
+    import datetime
+
+    from aurumq_rl.portfolio_weight_env import PortfolioWeightConfig, PortfolioWeightEnv
+
+    n_dates, n_stocks, n_factors = 30, 8, 4
+    rng = np.random.default_rng(0)
+    factor = rng.standard_normal((n_dates, n_stocks, n_factors)).astype(np.float32)
+    ret = (rng.standard_normal((n_dates, n_stocks)) * 0.01).astype(np.float32)
+
+    config = PortfolioWeightConfig(
+        start_date=datetime.date(2022, 1, 1),
+        end_date=datetime.date(2022, 12, 31),
+        n_factors=n_factors,
+        forward_period=2,
+        reward_type="differential_sharpe",
+        cost_bps=0.0,
+        turnover_penalty=0.0,
+    )
+    env = PortfolioWeightEnv(config=config, factor_panel=factor, return_panel=ret)
+    env.reset(seed=0)
+
+    action = np.full(n_stocks, 0.5, dtype=np.float32)
+    _, reward, *_ = env.step(action)
+    assert reward == 0.0  # warm-up: step 0 has degenerate DSR history
+
+    rewards = [reward]
+    for _ in range(n_dates - 3):
+        _, reward, terminated, _, _ = env.step(action)
+        rewards.append(reward)
+        if terminated:
+            break
+
+    assert all(np.isfinite(r) for r in rewards)
+    assert max(abs(r) for r in rewards) < 1e3
+
+    # A fresh episode must not leak the previous episode's DSR state.
+    env.reset(seed=0)
+    _, reward0, *_ = env.step(action)
+    assert reward0 == 0.0


### PR DESCRIPTION
Closes #2.

## What
Adds a **Differential Sharpe Ratio** (Moody & Saffell 1998) reward mode — a config-selectable alternative to the rolling Sharpe/Sortino modes. DSR is the exact per-step incremental contribution to the Sharpe ratio via exponentially-decayed moving averages of returns (A) and squared returns (B): bounded, O(1)/step, and it makes γ/GAE-λ meaningful (summing a rolling Sharpe optimizes neither Sharpe nor return, and was the root of the C5 spike).

## Design notes
- Stateful `DifferentialSharpe(eta)` in `reward_functions.py` (`.update(r)`, `.reset()`), owned by the env, fed the **same** per-step portfolio return the rolling Sharpe consumes, reset per episode.
- **Warm-start A,B from the first observation** (not zero) — this is what keeps DSR bounded. Zero-init produces a cold-start phantom-variance transient that spikes `|DSR| ≈ 0.5·|R|/VOLATILITY_FLOOR` mid-trajectory (≈990 at ±20% limit-up magnitude); warm-starting makes a constant stream give **exactly 0.0 at any magnitude**. Verified: constant r∈{0.01,0.2,0.5} → peak 0.0; varying stream → finite (max ~4.6).
- Existing reward modes are byte-for-byte unchanged; `dsr_eta` exposed via config/CLI mirroring `risk_aversion`.

## Tests
+9 tests (formula pinning, boundedness incl. the r=0.20 case that catches the cold-start bug, reset/no-leakage, cumulative-Sharpe direction over a 30-seed ensemble, env wiring). Suite 1657 passed / 127 skipped / 31 xfailed. CI gates green locally: ruff check, ruff format --check, pytest, CLI smoke (`status=ok`).

## Deferred (needs GPU/data box)
Real-data OOS comparison of `differential_sharpe` vs rolling sharpe/sortino, and `dsr_eta` sensitivity — no market data in this checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)