### PR TITLE
feat(cv): purged + embargoed walk-forward CV (closes #5)

### DIFF
--- a/src/aurumq_rl/__init__.py
+++ b/src/aurumq_rl/__init__.py
@@ -45,6 +45,8 @@ __all__ = [
     # Data
     "FactorPanelLoader",
     "FactorPanel",
+    # Cross-validation
+    "PurgedWalkForwardCV",
     # Constants
     "StockBoard",
     "identify_board",
@@ -53,6 +55,7 @@ __all__ = [
 ]
 
 # Always-available imports (no PyTorch required)
+from aurumq_rl.cv import PurgedWalkForwardCV
 from aurumq_rl.data_loader import FactorPanel, FactorPanelLoader
 from aurumq_rl.inference import RlAgentInference, RlAgentMetadata
 from aurumq_rl.price_limits import (

--- a/src/aurumq_rl/cv.py
+++ b/src/aurumq_rl/cv.py
@@ -1,0 +1,234 @@
+"""Purged + embargoed walk-forward cross-validation (López de Prado, ch. 7).
+
+Forward-constructed labels (anchor / triple-barrier / trend-scanning) in this
+repo embed information from ``[d+1, d+K]`` at date ``d`` (``K`` =
+``label_horizon_days``). Any CV split that lets a validation sample sit
+within ``K`` days of a training sample leaks label information backward into
+training. :class:`PurgedWalkForwardCV` generalizes the single ad-hoc split in
+``scripts/p3/kronos_matrix_v13_lib.py::date_embargo_split`` into a reusable,
+multi-fold, sklearn-compatible splitter.
+
+Units — trading days, not calendar days
+----------------------------------------
+``label_horizon_days`` and ``embargo_days`` are counted as **positions in the
+sorted unique-date sequence** (i.e. "trading days" — the same convention as
+``date_embargo_split``'s ``EMBARGO_DAYS``), NOT calendar-day deltas. This
+keeps the splitter agnostic to the concrete type of the date column (it may
+be an actual date, a ``trade_date`` integer code, or any other sortable
+value) and matches the precedent this class generalizes.
+
+API — ``groups=``, not a constructor ``dates=``
+-------------------------------------------------
+Per-row dates are passed to :meth:`split` / :meth:`get_n_splits` via the
+standard scikit-learn ``groups`` parameter (as in ``GroupKFold``), not a
+constructor argument. This keeps the splitter instance stateless/reusable
+across differently-shaped panels and is the literal shape LightGBM/sklearn
+expect when they call ``cv.split(X, y, groups)``.
+
+No lookahead
+------------
+For every fold, every training row's date position ``p`` satisfies
+``p + label_horizon_days < test_start`` (strict), so a train sample's label
+horizon never reaches into the test fold. Embargo additionally excludes
+training rows within ``embargo_days`` immediately after any *earlier* fold's
+test window — relevant once an earlier fold's test period is absorbed into a
+later fold's (expanding or rolling) training window.
+
+Empty-train behavior
+---------------------
+If purge + embargo remove every candidate training row for a fold, that fold
+is still yielded (so ``len(list(cv.split(...))) == cv.get_n_splits()``
+always holds) with an empty ``train_idx`` array rather than being skipped.
+Callers that cannot tolerate an empty training fold should check
+``train_idx.size`` themselves.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any, Literal
+
+import numpy as np
+
+__all__ = ["PurgedWalkForwardCV"]
+
+_Mode = Literal["expanding", "rolling"]
+
+
+def _num_samples(x: Any) -> int:
+    """Row count of an array-like, without requiring sklearn/pandas."""
+    if hasattr(x, "shape"):
+        return int(x.shape[0])
+    return len(x)
+
+
+class PurgedWalkForwardCV:
+    """Purged + embargoed walk-forward CV splitter (scikit-learn compatible).
+
+    Splits rows into ``n_splits`` forward-advancing (train, test) folds over
+    the sorted **unique** dates supplied via ``groups``. All rows sharing a
+    date always land on the same side of every split. Training rows whose
+    label horizon would overlap the test fold are purged, and rows within
+    ``embargo_days`` after any earlier fold's test window are additionally
+    embargoed (see module docstring for exact semantics and units).
+
+    Drops into scikit-learn / LightGBM ``cv=`` slots: implements
+    ``get_n_splits(X, y, groups)`` and ``split(X, y, groups) ->
+    Iterator[(train_idx, test_idx)]``.
+
+    Args:
+        n_splits: number of test folds.
+        label_horizon_days: ``K`` — a training sample at date position ``p``
+            is purged from a fold if ``p + K >= test_start`` (its label
+            window would overlap the test fold). Trading-day units (see
+            module docstring). ``0`` disables purging.
+        embargo_days: number of trading days immediately after an *earlier*
+            fold's test window that are excluded from training in later
+            folds. ``0`` disables embargoing.
+        mode: ``"expanding"`` (default) — training uses every date before
+            the test fold's purge cutoff. ``"rolling"`` — training uses a
+            fixed-size window of ``max_train_size`` (or ``test_size`` if
+            unset) dates immediately preceding the purge cutoff.
+        test_size: number of unique dates per test fold. Defaults to
+            ``n_unique_dates // (n_splits + 1)`` (mirrors
+            ``sklearn.model_selection.TimeSeriesSplit``: the earliest chunk
+            of dates is reserved purely for initial training).
+        max_train_size: rolling-mode only; maximum number of unique dates in
+            the training window. Ignored in expanding mode.
+
+    Raises:
+        ValueError: invalid constructor arguments (checked eagerly), or
+            (raised lazily, on iteration) too few unique dates for the
+            requested ``n_splits`` / ``test_size``.
+    """
+
+    def __init__(
+        self,
+        n_splits: int = 5,
+        *,
+        label_horizon_days: int = 0,
+        embargo_days: int = 0,
+        mode: _Mode = "expanding",
+        test_size: int | None = None,
+        max_train_size: int | None = None,
+    ) -> None:
+        if n_splits < 1:
+            raise ValueError(f"n_splits must be >= 1, got {n_splits}")
+        if label_horizon_days < 0:
+            raise ValueError(f"label_horizon_days must be >= 0, got {label_horizon_days}")
+        if embargo_days < 0:
+            raise ValueError(f"embargo_days must be >= 0, got {embargo_days}")
+        if mode not in ("expanding", "rolling"):
+            raise ValueError(f"mode must be 'expanding' or 'rolling', got {mode!r}")
+        if test_size is not None and test_size < 1:
+            raise ValueError(f"test_size must be >= 1, got {test_size}")
+        if max_train_size is not None and max_train_size < 1:
+            raise ValueError(f"max_train_size must be >= 1, got {max_train_size}")
+
+        self.n_splits = n_splits
+        self.label_horizon_days = label_horizon_days
+        self.embargo_days = embargo_days
+        self.mode = mode
+        self.test_size = test_size
+        self.max_train_size = max_train_size
+
+    def get_n_splits(self, X: Any = None, y: Any = None, groups: Any = None) -> int:
+        """Number of folds (sklearn splitter interface; args are unused)."""
+        del X, y, groups  # static value, kept for interface compatibility
+        return self.n_splits
+
+    def split(
+        self, X: Any, y: Any = None, groups: Any = None
+    ) -> Iterator[tuple[np.ndarray, np.ndarray]]:
+        """Yield ``(train_idx, test_idx)`` row-index arrays for each fold.
+
+        Args:
+            X: array-like used only to validate row count against ``groups``
+                (its values are never inspected). May be ``None`` to skip
+                that check.
+            y: unused; accepted for sklearn interface compatibility.
+            groups: required — per-row date array (any sortable dtype),
+                length == number of rows.
+
+        Yields:
+            ``(train_idx, test_idx)``: sorted ``int64`` row-index arrays into
+            the original (unpermuted) ``groups`` array. Exactly
+            ``get_n_splits()`` pairs are yielded; ``train_idx`` may be empty
+            (see module docstring "Empty-train behavior").
+
+        Raises:
+            ValueError: ``groups`` is ``None``/empty, its length mismatches
+                ``X``, or there are too few unique dates for the requested
+                ``n_splits`` / ``test_size``.
+        """
+        del y  # unused; accepted for sklearn interface compatibility
+        if groups is None:
+            raise ValueError(
+                "PurgedWalkForwardCV.split() requires groups=<per-row date array>; "
+                "pass the date column via the standard sklearn `groups` kwarg "
+                "(this splitter holds no data of its own)."
+            )
+        dates = np.asarray(groups)
+        if dates.size == 0:
+            raise ValueError("groups must be non-empty")
+        if X is not None:
+            n_rows = _num_samples(X)
+            if len(dates) != n_rows:
+                raise ValueError(f"groups length {len(dates)} != X length {n_rows}")
+
+        unique_dates = np.unique(dates)
+        n_dates = len(unique_dates)
+
+        test_size = self.test_size or n_dates // (self.n_splits + 1)
+        if test_size < 1:
+            raise ValueError(
+                f"cannot derive test_size from {n_dates} unique dates and "
+                f"n_splits={self.n_splits}; need >= {self.n_splits + 1} unique "
+                f"dates, or pass test_size explicitly"
+            )
+
+        # Test windows are precomputed up front (as [start, end) positions
+        # into unique_dates) so later folds can look back at earlier folds'
+        # test boundaries for the embargo rule.
+        test_windows: list[tuple[int, int]] = []
+        for i in range(self.n_splits):
+            test_start = n_dates - (self.n_splits - i) * test_size
+            test_end = test_start + test_size
+            if test_start < 0:
+                raise ValueError(
+                    f"not enough unique dates ({n_dates}) for n_splits="
+                    f"{self.n_splits} with test_size={test_size}; reduce "
+                    f"n_splits/test_size or supply more history"
+                )
+            test_windows.append((test_start, test_end))
+
+        for i, (test_start, test_end) in enumerate(test_windows):
+            if self.mode == "expanding":
+                train_start = 0
+            else:  # rolling
+                span = self.max_train_size or test_size
+                train_start = max(0, test_start - span)
+
+            # Purge: keep only train positions whose label horizon ends
+            # strictly before the test fold starts (p + K < test_start).
+            purge_cutoff = max(train_start, test_start - self.label_horizon_days)
+            train_positions = np.arange(train_start, purge_cutoff)
+
+            # Embargo: drop positions within embargo_days after any EARLIER
+            # fold's test window (matters once that fold's test period is
+            # absorbed into a later training window; see module docstring).
+            if self.embargo_days > 0 and train_positions.size > 0:
+                keep = np.ones(train_positions.shape[0], dtype=bool)
+                for _prev_start, prev_end in test_windows[:i]:
+                    embargo_lo = prev_end
+                    embargo_hi = prev_end + self.embargo_days
+                    keep &= ~((train_positions >= embargo_lo) & (train_positions < embargo_hi))
+                train_positions = train_positions[keep]
+
+            train_dates = unique_dates[train_positions]
+            test_dates = unique_dates[test_start:test_end]
+
+            train_idx = np.flatnonzero(np.isin(dates, train_dates)).astype(np.int64)
+            test_idx = np.flatnonzero(np.isin(dates, test_dates)).astype(np.int64)
+
+            yield train_idx, test_idx

--- a/tests/test_cv.py
+++ b/tests/test_cv.py
@@ -1,0 +1,280 @@
+"""Unit tests for src/aurumq_rl/cv.py — purged + embargoed walk-forward CV.
+
+All synthetic, no real data. Dates are consecutive integers ``0..n_dates-1``
+so "trading-day index" and "date value" coincide, which sidesteps any
+ambiguity about whether ``label_horizon_days`` / ``embargo_days`` are counted
+as calendar-day deltas or unique-date positions (see module docstring in
+``aurumq_rl/cv.py`` — they are unique-date positions, matching
+``kronos_matrix_v13_lib.date_embargo_split``'s "trading calendar" convention).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from aurumq_rl.cv import PurgedWalkForwardCV
+
+
+def _synthetic_dates(n_dates: int = 60, n_symbols: int = 5, seed: int = 0) -> np.ndarray:
+    """Row-per-(date, symbol) date array, e.g. 60 dates x 5 symbols = 300 rows."""
+    rng = np.random.default_rng(seed)
+    dates = np.repeat(np.arange(n_dates), n_symbols)
+    order = rng.permutation(len(dates))
+    return dates[order]
+
+
+# ---------------------------------------------------------------------------
+# 1. Purge correctness
+# ---------------------------------------------------------------------------
+
+
+def test_purge_removes_label_horizon_overlap():
+    dates = _synthetic_dates(n_dates=60, n_symbols=4, seed=1)
+    K = 5
+    cv = PurgedWalkForwardCV(n_splits=4, label_horizon_days=K, embargo_days=0)
+    folds = list(cv.split(X=None, groups=dates))
+    assert len(folds) == 4
+    for train_idx, test_idx in folds:
+        if train_idx.size == 0:
+            continue
+        first_test_date = dates[test_idx].min()
+        train_dates = dates[train_idx]
+        assert (train_dates + K < first_test_date).all(), (
+            f"purge violated: some train date + {K} >= {first_test_date}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 2. Embargo correctness
+# ---------------------------------------------------------------------------
+
+
+def test_embargo_removes_post_test_window():
+    # n_splits=3, n_dates=60 -> test_size=15, contiguous folds [15,30) [30,45) [45,60).
+    # Fold 0's test ends at date 30; embargo=4 must keep dates [30, 34) out of
+    # training for LATER folds that would otherwise absorb them (fold 2 here,
+    # since fold 1's own test occupies [30, 45) already).
+    dates = _synthetic_dates(n_dates=60, n_symbols=3, seed=2)
+    embargo_days = 4
+
+    cv_embargo = PurgedWalkForwardCV(n_splits=3, label_horizon_days=0, embargo_days=embargo_days)
+    folds_embargo = list(cv_embargo.split(X=None, groups=dates))
+
+    cv_baseline = PurgedWalkForwardCV(n_splits=3, label_horizon_days=0, embargo_days=0)
+    folds_baseline = list(cv_baseline.split(X=None, groups=dates))
+
+    train_idx_fold2, test_idx_fold2 = folds_embargo[2]
+    train_dates_fold2 = set(np.unique(dates[train_idx_fold2]).tolist())
+    embargo_zone = set(range(30, 30 + embargo_days))
+    assert not (train_dates_fold2 & embargo_zone), (
+        f"embargoed dates {embargo_zone} leaked into fold-2 train: "
+        f"{train_dates_fold2 & embargo_zone}"
+    )
+
+    # Non-vacuous: without embargo, that zone WOULD have been train data.
+    base_train_idx_fold2, _ = folds_baseline[2]
+    base_train_dates_fold2 = set(np.unique(dates[base_train_idx_fold2]).tolist())
+    assert base_train_dates_fold2 & embargo_zone, (
+        "test setup invalid: baseline (embargo_days=0) fold-2 train does not "
+        "even contain the zone under test, so the embargo assertion is vacuous"
+    )
+
+    # General property: no fold's train ever contains a date within
+    # embargo_days after any EARLIER fold's test window.
+    test_windows = []
+    for _, test_idx in folds_embargo:
+        if test_idx.size:
+            test_windows.append((dates[test_idx].min(), dates[test_idx].max()))
+    for i, (train_idx, _) in enumerate(folds_embargo):
+        if train_idx.size == 0:
+            continue
+        train_dates = set(np.unique(dates[train_idx]).tolist())
+        for j in range(i):
+            _, prev_test_max = test_windows[j]
+            forbidden = set(range(prev_test_max + 1, prev_test_max + 1 + embargo_days))
+            assert not (train_dates & forbidden), (
+                f"fold {i} train contains dates embargoed after fold {j}'s test"
+            )
+
+
+# ---------------------------------------------------------------------------
+# 3. Walk-forward direction
+# ---------------------------------------------------------------------------
+
+
+def test_walk_forward_direction_strictly_forward():
+    dates = _synthetic_dates(n_dates=80, n_symbols=3, seed=3)
+    cv = PurgedWalkForwardCV(n_splits=5, label_horizon_days=2, embargo_days=1)
+    folds = list(cv.split(X=None, groups=dates))
+    assert len(folds) == 5
+    prior_test_max = -np.inf
+    for train_idx, test_idx in folds:
+        assert test_idx.size > 0
+        test_min = dates[test_idx].min()
+        test_max = dates[test_idx].max()
+        if train_idx.size:
+            assert dates[train_idx].max() < test_min, "train must precede test strictly"
+        # folds advance forward: this fold's test starts after the previous one's ended.
+        assert test_min > prior_test_max
+        prior_test_max = test_max
+
+
+# ---------------------------------------------------------------------------
+# 4. Determinism under row permutation
+# ---------------------------------------------------------------------------
+
+
+def test_determinism_under_row_permutation():
+    base_dates = _synthetic_dates(n_dates=50, n_symbols=4, seed=4)
+    rng = np.random.default_rng(99)
+    shuffled_order = rng.permutation(len(base_dates))
+    shuffled_dates = base_dates[shuffled_order]
+
+    cv1 = PurgedWalkForwardCV(n_splits=4, label_horizon_days=3, embargo_days=2)
+    cv2 = PurgedWalkForwardCV(n_splits=4, label_horizon_days=3, embargo_days=2)
+
+    folds1 = list(cv1.split(X=None, groups=base_dates))
+    folds2 = list(cv2.split(X=None, groups=shuffled_dates))
+
+    assert len(folds1) == len(folds2)
+    for (train1, test1), (train2, test2) in zip(folds1, folds2, strict=True):
+        train_dates1 = set(np.unique(base_dates[train1]).tolist())
+        train_dates2 = set(np.unique(shuffled_dates[train2]).tolist())
+        test_dates1 = set(np.unique(base_dates[test1]).tolist())
+        test_dates2 = set(np.unique(shuffled_dates[test2]).tolist())
+        assert train_dates1 == train_dates2
+        assert test_dates1 == test_dates2
+
+
+# ---------------------------------------------------------------------------
+# 5. Whole-date grouping
+# ---------------------------------------------------------------------------
+
+
+def test_whole_date_grouping_never_splits_a_date():
+    dates = _synthetic_dates(n_dates=50, n_symbols=6, seed=5)
+    cv = PurgedWalkForwardCV(n_splits=4, label_horizon_days=2, embargo_days=1)
+    for train_idx, test_idx in cv.split(X=None, groups=dates):
+        train_dates = set(dates[train_idx].tolist())
+        test_dates = set(dates[test_idx].tolist())
+        assert not (train_dates & test_dates), "a date must never appear on both sides"
+        # every row for a given date must land in the same set as every other
+        # row sharing that date.
+        for d in train_dates:
+            rows_for_d = np.flatnonzero(dates == d)
+            assert set(rows_for_d.tolist()).issubset(set(train_idx.tolist()))
+        for d in test_dates:
+            rows_for_d = np.flatnonzero(dates == d)
+            assert set(rows_for_d.tolist()).issubset(set(test_idx.tolist()))
+
+
+# ---------------------------------------------------------------------------
+# 6. sklearn interface smoke
+# ---------------------------------------------------------------------------
+
+
+def test_sklearn_interface_smoke():
+    dates = _synthetic_dates(n_dates=50, n_symbols=5, seed=6)
+    n_rows = len(dates)
+    X = np.zeros((n_rows, 3))
+    cv = PurgedWalkForwardCV(n_splits=5, label_horizon_days=1, embargo_days=1)
+
+    assert cv.get_n_splits(X, groups=dates) == 5
+
+    folds = list(cv.split(X, groups=dates))
+    assert len(folds) == cv.get_n_splits(X, groups=dates)
+
+    for train_idx, test_idx in folds:
+        assert np.issubdtype(train_idx.dtype, np.integer)
+        assert np.issubdtype(test_idx.dtype, np.integer)
+        if train_idx.size:
+            assert train_idx.min() >= 0
+            assert train_idx.max() < n_rows
+        assert test_idx.min() >= 0
+        assert test_idx.max() < n_rows
+        assert len(set(train_idx.tolist()) & set(test_idx.tolist())) == 0
+
+
+def test_groups_required():
+    dates = _synthetic_dates(n_dates=20, n_symbols=2, seed=7)
+    cv = PurgedWalkForwardCV(n_splits=2)
+    with pytest.raises(ValueError, match="groups"):
+        list(cv.split(X=np.zeros((len(dates), 1)), groups=None))
+
+
+def test_groups_length_mismatch_raises():
+    dates = _synthetic_dates(n_dates=20, n_symbols=2, seed=8)
+    cv = PurgedWalkForwardCV(n_splits=2)
+    with pytest.raises(ValueError, match="length"):
+        list(cv.split(X=np.zeros((len(dates) - 1, 1)), groups=dates))
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"n_splits": 0},
+        {"n_splits": 2, "label_horizon_days": -1},
+        {"n_splits": 2, "embargo_days": -1},
+        {"n_splits": 2, "mode": "sideways"},
+        {"n_splits": 2, "test_size": 0},
+        {"n_splits": 2, "max_train_size": 0},
+    ],
+)
+def test_invalid_constructor_args_raise(kwargs):
+    with pytest.raises(ValueError):
+        PurgedWalkForwardCV(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# 7. Edge case: purge/embargo large enough to empty a train fold
+# ---------------------------------------------------------------------------
+
+
+def test_large_horizon_yields_empty_train_not_skipped_fold():
+    dates = _synthetic_dates(n_dates=40, n_symbols=3, seed=9)
+    # label_horizon_days larger than the entire pre-test span empties fold 0's
+    # train under the documented behavior: the fold is still yielded (matching
+    # get_n_splits()), with an empty (but valid-dtype) train index array.
+    cv = PurgedWalkForwardCV(n_splits=4, label_horizon_days=1000, embargo_days=0)
+    folds = list(cv.split(X=None, groups=dates))
+    assert len(folds) == cv.get_n_splits() == 4
+
+    train_idx0, test_idx0 = folds[0]
+    assert train_idx0.size == 0
+    assert np.issubdtype(train_idx0.dtype, np.integer)
+    assert test_idx0.size > 0
+
+
+# ---------------------------------------------------------------------------
+# Rolling mode
+# ---------------------------------------------------------------------------
+
+
+def test_rolling_mode_bounds_train_span():
+    dates = _synthetic_dates(n_dates=80, n_symbols=3, seed=10)
+    max_train_size = 10
+    cv = PurgedWalkForwardCV(
+        n_splits=4,
+        label_horizon_days=1,
+        embargo_days=0,
+        mode="rolling",
+        max_train_size=max_train_size,
+    )
+    for train_idx, test_idx in cv.split(X=None, groups=dates):
+        if train_idx.size == 0:
+            continue
+        n_unique_train_dates = len(np.unique(dates[train_idx]))
+        assert n_unique_train_dates <= max_train_size
+        assert dates[train_idx].max() < dates[test_idx].min()
+
+
+# ---------------------------------------------------------------------------
+# Public export
+# ---------------------------------------------------------------------------
+
+
+def test_exported_from_package_root():
+    from aurumq_rl import PurgedWalkForwardCV as ExportedCV
+
+    assert ExportedCV is PurgedWalkForwardCV


### PR DESCRIPTION
Closes #5.

## What
New reusable `PurgedWalkForwardCV` (`src/aurumq_rl/cv.py`, exported from the package root) implementing the sklearn splitter interface with López de Prado purging + embargo. Foundation for #6 (eval metrics) and #7 (p3 heads) — any sklearn/LightGBM `cv=` or manual loop can use it.

## Semantics (independently verified in review)
- **Purge**: a training sample at `date + label_horizon_days >= first_test_date` of its fold is removed (boundary probed: `date+K == test_start` IS purged, `test_start-1` kept).
- **Embargo**: removes post-test dates that would otherwise become live training data once absorbed by a later expanding window — applied against every earlier fold, at the earliest fold where the leak is structurally possible (correct generalization of LdP's k-fold embargo to walk-forward; not the weaker "next fold only" reading).
- Walk-forward, expanding (default) + rolling (`max_train_size`); operates on whole dates (row-order-independent, deterministic); purely positional trading-day arithmetic so it works for int / datetime64 / trade-date-code dtypes.
- Always yields `n_splits` folds so `get_n_splits() == len(list(split()))` unconditionally.

## Tests
+17 tests (`tests/test_cv.py`): purge & embargo leakage assertions (with non-vacuous baseline guards), walk-forward direction, permutation determinism, whole-date grouping, sklearn-interface consistency, rolling mode, empty-fold edge. Suite 1662 passed. CI gates green locally (ruff check, ruff format --check, pytest, smoke `status=ok`).

## Minor follow-up (non-blocking)
Tests use consecutive-integer dates; a `np.datetime64` business-day-gap case would make the "any sortable dtype" claim verifiable rather than asserted. Impl is purely positional so correctness is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)