### PR TITLE
feat(labeling): CUSUM sampling + concurrency weights + t-stat cap + horizon scaling (closes #8)

### DIFF
--- a/src/aurumq_rl/labeling/README.md
+++ b/src/aurumq_rl/labeling/README.md
@@ -169,8 +169,73 @@ caller produces the arrays from whatever bundle source.
 ## Test pass
 
 ```
-21 / 21 passed
-- tests/labeling/test_events_dedupe.py     8 (event primitive + horizon derivation)
-- tests/labeling/test_methods_synthetic.py 9 (A/B/C/D detect known patterns)
-- tests/labeling/test_thresholds.py        4 (target-pos-rate search)
+41 / 41 passed
+- tests/labeling/test_events_dedupe.py             8 (event primitive + horizon derivation)
+- tests/labeling/test_methods_synthetic.py         9 (A/B/C/D detect known patterns)
+- tests/labeling/test_thresholds.py                4 (target-pos-rate search)
+- tests/labeling/test_sampling.py                 10 (CUSUM filter + concurrency/uniqueness)
+- tests/labeling/test_trend_scanning_transform.py  4 (t-stat squashing, opt-in)
+- tests/labeling/test_v2_horizon_scaling.py        6 (√horizon threshold scaling, opt-in, P0-locked default)
 ```
+
+---
+
+## Issue #8 — López de Prado alignments (all opt-in / additive)
+
+Four additions layered on top of the methods above. **None of them change any
+existing method's default output** — every new parameter defaults to the
+current (pre-issue-8) behavior. See `sampling.py` module docstring and each
+function's docstring for full detail.
+
+### Part 1 — CUSUM event filter (`sampling.cusum_filter`)
+
+Symmetric CUSUM filter (LdP ch. 2.5.2): accumulates positive/negative run-sums
+of consecutive diffs, emits an event and resets whenever either run-sum
+crosses `±threshold`. Use this to sample *where* to seed candidate decision
+days instead of scanning every `t` (which clusters seeds in autocorrelated
+stretches).
+
+`triple_barrier.detect_events_triple_barrier(panel, event_idx=...)` accepts an
+OPT-IN `{ts_code: index_array}` mapping (e.g. built from `cusum_filter`) to
+restrict candidate decision days per stock. `event_idx=None` (default)
+preserves the original all-`t` seeding exactly.
+
+### Part 2 — concurrency / average uniqueness (`sampling.py`)
+
+`label_concurrency(t_starts, t_ends, index)` counts, per bar, how many
+labels' `[t_start, t_end]` outcome windows are live (LdP ch. 4).
+`average_uniqueness(t_starts, t_ends, index)` turns that into a per-label
+`sample_weight` (mean of `1/concurrency` over the label's own window) —
+labels whose outcome windows heavily overlap get down-weighted when fed to
+LightGBM. Both are new, standalone utilities; no existing label emitter is
+changed by their presence.
+
+### Part 3 — trend-scanning t-stat squashing (`trend_scanning.detect_events_trend_scanning(..., tstat_transform=...)`)
+
+Raw `|t_stat|` is unbounded — low-vol micro-drifts can produce t-stats in the
+thousands that dominate `search_threshold`-based selection, favoring smooth
+drifts over genuine main waves. `tstat_transform` is OPT-IN:
+
+- `"raw"` (default): current behavior, unbounded `event_quality = t_stat`.
+- `"tanh"` (**recommended**): `tanh(t_stat / 10) * 10` — smoothly bounded,
+  sign-preserving, near-linear for `|t_stat| << 10`.
+- `"clip"`: hard-clips to `[-10, 10]`.
+
+Selection of which forward window `L` wins per `t` (and the up/down direction
+gate) always uses the raw t-stat; the transform only affects the reported
+`event_quality`.
+
+### Part 4 — √horizon vol scaling (`v2_excess_adaptive.detect_events_v2(..., horizon_scaling=...)`, `adaptive_threshold`)
+
+**GUARDRAIL — P0-locked**: `v2_excess_adaptive` is the ablation winner (see
+top of this file); its default label output is locked and must not change.
+
+The P0 threshold `max(0.06, 1.8 * vol20)` compares a *daily* EWM vol against
+an up-to-20-day *cumulative* excess return with no √horizon scaling, so the
+6% floor binds almost always and the label is effectively non-adaptive.
+`horizon_scaling: bool = False` (default) reproduces the P0-locked formula
+byte-for-byte. `horizon_scaling=True` scales the vol term by
+`sqrt(duration)` (`adaptive_threshold(vol20, duration, horizon_scaling=True)
+= max(0.06, 1.8 * vol20 * sqrt(duration))`), where `duration` is the realized
+peak offset. **Enabling this changes the P0-locked label and requires a
+re-ablation before production use — do not flip the default.**

--- a/src/aurumq_rl/labeling/__init__.py
+++ b/src/aurumq_rl/labeling/__init__.py
@@ -22,6 +22,11 @@ Public API
 - derive_labels:                  events → (t, j) binary labels at horizon
 - search_threshold:               target-pos-rate threshold search
 - scan_main_wave_p0:              top-level convenience: A_t3 with τ=1.2327
+- cusum_filter:                   symmetric CUSUM event sampler (opt-in seeding, issue #8 Part 1)
+- label_concurrency:              per-bar overlap count for outcome windows (issue #8 Part 2)
+- average_uniqueness:             per-label sample_weight from concurrency (issue #8 Part 2)
+- adaptive_threshold:             v2_excess_adaptive threshold formula, opt-in √horizon scaling
+                                   (issue #8 Part 4; P0-locked default unaffected)
 
 Example
 -------
@@ -35,10 +40,11 @@ Example
 from .directional_change import detect_events_directional_change
 from .events import Event, dedupe_events, derive_labels, events_to_dataframe
 from .panels import MarketPanel
+from .sampling import average_uniqueness, cusum_filter, label_concurrency
 from .thresholds import ThresholdResult, search_threshold
 from .trend_scanning import detect_events_trend_scanning
 from .triple_barrier import detect_events_triple_barrier
-from .v2_excess_adaptive import detect_events_v2
+from .v2_excess_adaptive import adaptive_threshold, detect_events_v2
 
 # ---------------------------------------------------------------------------
 # P0 locked configuration (data-side ablation winner)
@@ -89,6 +95,10 @@ __all__ = [
     "detect_events_triple_barrier",
     "detect_events_directional_change",
     "scan_main_wave_p0",
+    "cusum_filter",
+    "label_concurrency",
+    "average_uniqueness",
+    "adaptive_threshold",
     "P0_LABEL_NAME",
     "P0_HORIZON",
     "P0_THRESHOLD",

--- a/src/aurumq_rl/labeling/sampling.py
+++ b/src/aurumq_rl/labeling/sampling.py
@@ -1,0 +1,152 @@
+"""Event sampling and sample-weighting utilities (López de Prado, 2018).
+
+These are additive, opt-in utilities layered on top of the existing labeling
+methods in this package. Nothing here changes any existing label emitter's
+default output — see `triple_barrier.detect_events_triple_barrier`'s
+`event_idx` parameter for the opt-in wiring point (ch. 2.5.2), and
+`v2_excess_adaptive` / training code for where `label_concurrency` /
+`average_uniqueness` sample weights (ch. 4) can be consumed downstream.
+
+Part 1 — CUSUM filter
+----------------------
+`cusum_filter` implements the symmetric CUSUM event-sampling filter: it
+accumulates positive/negative run-sums of consecutive diffs and emits an
+event (resetting the run-sum) whenever either crosses `+threshold` /
+`-threshold`. This concentrates event seeds at genuine level shifts instead
+of sampling every bar, which is what `triple_barrier`'s default (all-t)
+seeding does.
+
+Part 2 — concurrency / average uniqueness
+------------------------------------------
+`label_concurrency` counts, for each bar, how many labels' outcome windows
+`[t_start, t_end]` are "live" at that bar. `average_uniqueness` turns that
+into a per-label weight (`sample_weight`) equal to the mean of `1/concurrency`
+over the label's own window — labels whose outcome windows heavily overlap
+other labels get down-weighted.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+__all__ = ["cusum_filter", "label_concurrency", "average_uniqueness"]
+
+
+def cusum_filter(series: np.ndarray, threshold: float) -> np.ndarray:
+    """Symmetric CUSUM event filter (LdP, *Advances in Financial ML*, ch. 2.5.2).
+
+    Accumulates positive and negative run-sums of consecutive first differences
+    of `series`. Whenever either run-sum crosses `+threshold` / `-threshold`,
+    an event is emitted at that index and both run-sums reset to zero.
+
+    Parameters
+    ----------
+    series
+        1-D array of a level series (e.g. price or cumulative log-return).
+    threshold
+        Symmetric CUSUM trigger level (same units as `series`); must be > 0.
+
+    Returns
+    -------
+    np.ndarray
+        Sorted, strictly increasing int64 array of event indices into `series`
+        (index `i+1` for a diff at position `i`, i.e. the index of the
+        observation that caused the crossing).
+    """
+    if threshold <= 0:
+        raise ValueError(f"cusum_filter threshold must be > 0, got {threshold}")
+    series = np.asarray(series, dtype=np.float64)
+    diffs = np.diff(series)
+    events: list[int] = []
+    s_pos = 0.0
+    s_neg = 0.0
+    for i, d in enumerate(diffs):
+        if not np.isfinite(d):
+            continue
+        s_pos = max(0.0, s_pos + d)
+        s_neg = min(0.0, s_neg + d)
+        if s_neg < -threshold:
+            s_neg = 0.0
+            events.append(i + 1)
+        elif s_pos > threshold:
+            s_pos = 0.0
+            events.append(i + 1)
+    return np.array(events, dtype=np.int64)
+
+
+def label_concurrency(t_starts: np.ndarray, t_ends: np.ndarray, index: np.ndarray) -> np.ndarray:
+    """Count how many labels' outcome windows cover each bar in `index`.
+
+    Parameters
+    ----------
+    t_starts, t_ends
+        1-D integer arrays (same length), the closed `[t_start_i, t_end_i]`
+        outcome window of each label, in the same integer bar-index space as
+        `index`.
+    index
+        1-D sorted-ascending integer array of bar positions to evaluate
+        concurrency at (typically all bars in the sample, e.g. `0..T-1`).
+
+    Returns
+    -------
+    np.ndarray
+        int64 array, same length as `index`: `concurrency[k]` = number of
+        labels whose `[t_start, t_end]` window contains `index[k]`.
+    """
+    t_starts = np.asarray(t_starts, dtype=np.int64)
+    t_ends = np.asarray(t_ends, dtype=np.int64)
+    index = np.asarray(index, dtype=np.int64)
+    if t_starts.shape != t_ends.shape:
+        raise ValueError("t_starts and t_ends must have the same shape")
+    if index.size == 0:
+        return np.zeros(0, dtype=np.int64)
+
+    lo = int(index.min())
+    hi = int(index.max())
+    # Sweep-line diff array over the contiguous bar range [lo, hi].
+    diff = np.zeros(hi - lo + 2, dtype=np.int64)
+    for s, e in zip(t_starts, t_ends, strict=True):
+        s_c = max(int(s), lo)
+        e_c = min(int(e), hi)
+        if s_c > e_c:
+            continue
+        diff[s_c - lo] += 1
+        diff[e_c - lo + 1] -= 1
+    counts_full = np.cumsum(diff)[:-1]  # counts_full[p] = concurrency at bar (lo + p)
+    return counts_full[index - lo]
+
+
+def average_uniqueness(t_starts: np.ndarray, t_ends: np.ndarray, index: np.ndarray) -> np.ndarray:
+    """Per-label average uniqueness → sample weight vector (LdP ch. 4).
+
+    For each label `i` with outcome window `[t_start_i, t_end_i]`, computes
+    the mean of `1 / concurrency[b]` over all bars `b` in `index` that fall
+    within that window. A label whose window never overlaps any other
+    label's window gets weight 1.0; heavy overlap pulls the weight toward 0.
+
+    Parameters
+    ----------
+    t_starts, t_ends
+        1-D integer arrays (same length, one entry per label).
+    index
+        1-D sorted-ascending integer array of bar positions (the universe of
+        bars over which concurrency is computed).
+
+    Returns
+    -------
+    np.ndarray
+        float64 array, one weight per label (same length as `t_starts`).
+    """
+    t_starts = np.asarray(t_starts, dtype=np.int64)
+    t_ends = np.asarray(t_ends, dtype=np.int64)
+    index = np.asarray(index, dtype=np.int64)
+    concurrency = label_concurrency(t_starts, t_ends, index)
+
+    weights = np.zeros(len(t_starts), dtype=np.float64)
+    for i, (s, e) in enumerate(zip(t_starts, t_ends, strict=True)):
+        lo_pos = int(np.searchsorted(index, s, side="left"))
+        hi_pos = int(np.searchsorted(index, e, side="right"))
+        seg = concurrency[lo_pos:hi_pos]
+        seg = seg[seg > 0]
+        weights[i] = float(np.mean(1.0 / seg)) if seg.size > 0 else 0.0
+    return weights

--- a/src/aurumq_rl/labeling/trend_scanning.py
+++ b/src/aurumq_rl/labeling/trend_scanning.py
@@ -193,6 +193,12 @@ def detect_events_trend_scanning(
         always uses the raw t-stat — the transform only affects the reported
         `event_quality`.
     """
+    # Validate eagerly: a typo'd mode must fail immediately, not silently
+    # pass on a zero-event run and only raise once some event happens to fire.
+    if tstat_transform not in ("raw", "tanh", "clip"):
+        raise ValueError(
+            f"Unknown tstat_transform {tstat_transform!r}; expected 'raw', 'tanh', or 'clip'"
+        )
     events: list[Event] = []
     for j, ts_code in enumerate(panel.ts_codes):
         evs = _detect_events_one_stock(

--- a/src/aurumq_rl/labeling/trend_scanning.py
+++ b/src/aurumq_rl/labeling/trend_scanning.py
@@ -12,6 +12,8 @@ See SPEC §2.B.
 
 from __future__ import annotations
 
+from typing import Literal
+
 import numpy as np
 
 from .events import Event
@@ -21,6 +23,29 @@ __all__ = ["detect_events_trend_scanning"]
 
 
 L_GRID = (5, 10, 15, 20)
+
+# Part 3 (issue #8): opt-in t-stat quality squashing. Default "raw" reproduces
+# current (unbounded) event_quality exactly — see `_transform_tstat`.
+TstatTransform = Literal["raw", "tanh", "clip"]
+_TANH_SCALE = 10.0  # tanh(t / _TANH_SCALE) stays ~linear for |t| << _TANH_SCALE
+_TSTAT_CAP = 10.0  # bound used by both "tanh" (asymptote) and "clip" (hard cap)
+
+
+def _transform_tstat(t_stat: float, mode: TstatTransform) -> float:
+    """Squash/cap a raw t-stat quality score. Default "raw" is the identity.
+
+    Low-vol micro-drifts can produce raw t-stats in the hundreds/thousands
+    that dominate `search_threshold`-based selection, favoring smooth drifts
+    over genuine main waves. "tanh" and "clip" bound the score while
+    preserving sign (direction) and relative ordering for |t_stat| << cap.
+    """
+    if mode == "raw":
+        return t_stat
+    if mode == "tanh":
+        return float(np.tanh(t_stat / _TANH_SCALE) * _TSTAT_CAP)
+    if mode == "clip":
+        return float(np.clip(t_stat, -_TSTAT_CAP, _TSTAT_CAP))
+    raise ValueError(f"Unknown tstat_transform {mode!r}; expected 'raw', 'tanh', or 'clip'")
 
 
 def _vectorized_ols_tstat(y: np.ndarray, L: int) -> tuple[np.ndarray, np.ndarray]:
@@ -79,6 +104,7 @@ def _detect_events_one_stock(
     L_grid: tuple[int, ...] = L_GRID,
     amt_ma_window: int = 20,
     amt_min: float = 1e8,
+    tstat_transform: TstatTransform = "raw",
 ) -> list[Event]:
     n = len(adj_close)
     if n < max(L_grid) + 2:
@@ -127,12 +153,14 @@ def _detect_events_one_stock(
         if L_used <= 0:
             continue
         peak_idx = min(n - 1, t + L_used)
+        # Selection/gating above always uses the raw t-stat (best_t); the
+        # transform only affects the reported event_quality (Part 3, issue #8).
         events.append(
             Event(
                 ts_code=ts_code,
                 event_start_idx=t,
                 event_peak_idx=peak_idx,
-                event_quality=float(best_t[t]),
+                event_quality=_transform_tstat(float(best_t[t]), tstat_transform),
                 event_method="B",
             )
         )
@@ -141,8 +169,30 @@ def _detect_events_one_stock(
 
 
 def detect_events_trend_scanning(
-    panel: MarketPanel, L_grid: tuple[int, ...] = L_GRID
+    panel: MarketPanel,
+    L_grid: tuple[int, ...] = L_GRID,
+    *,
+    tstat_transform: TstatTransform = "raw",
 ) -> list[Event]:
+    """Detect Method B (trend-scanning) events.
+
+    Parameters
+    ----------
+    panel
+        Market panel (see `MarketPanel`).
+    L_grid
+        Forward-window lengths to fit OLS trends over.
+    tstat_transform
+        OPT-IN quality squashing (Part 3, issue #8). "raw" (default) reproduces
+        the current unbounded `event_quality = t_stat` exactly. "tanh" and
+        "clip" bound the reported quality so low-vol micro-drift t-stats in
+        the hundreds/thousands no longer dominate `search_threshold`-based
+        selection; "tanh" is the recommended setting (smoothly bounded,
+        sign-preserving, near-linear for small |t|). Selection of which
+        forward window `L` wins per `t` (and the up/down direction gate)
+        always uses the raw t-stat — the transform only affects the reported
+        `event_quality`.
+    """
     events: list[Event] = []
     for j, ts_code in enumerate(panel.ts_codes):
         evs = _detect_events_one_stock(
@@ -151,6 +201,7 @@ def detect_events_trend_scanning(
             amount=panel.amount[:, j],
             ts_code=ts_code,
             L_grid=L_grid,
+            tstat_transform=tstat_transform,
         )
         events.extend(evs)
     return events

--- a/src/aurumq_rl/labeling/triple_barrier.py
+++ b/src/aurumq_rl/labeling/triple_barrier.py
@@ -14,6 +14,8 @@ See SPEC §2.C.
 
 from __future__ import annotations
 
+from collections.abc import Iterable
+
 import numpy as np
 
 from ._common import ewm_std_1d, rolling_mean_1d
@@ -42,6 +44,7 @@ def _detect_events_one_stock(
     vol_halflife: float = DEFAULT_VOL_HALFLIFE,
     amt_ma_window: int = DEFAULT_AMT_MA_WINDOW,
     amt_min: float = DEFAULT_AMT_MIN,
+    event_idx: np.ndarray | None = None,
 ) -> list[Event]:
     n = len(adj_close)
     if n < vert_T + 2:
@@ -49,26 +52,28 @@ def _detect_events_one_stock(
     sigma = ewm_std_1d(pct_change, halflife=vol_halflife)
     amt_ma = rolling_mean_1d(amount, window=amt_ma_window)
 
+    # Candidate decision days to seed. Default (event_idx=None) preserves the
+    # original all-t seeding (LdP-style CUSUM sampling is opt-in — see
+    # sampling.cusum_filter — and must not change default behavior).
+    if event_idx is None:
+        candidates: Iterable[int] = range(1, n - vert_T)
+    else:
+        candidates = sorted(int(i) for i in event_idx if 1 <= int(i) < n - vert_T)
+
     events: list[Event] = []
     last_peak = -1
-    t = 1
-    while t < n - vert_T:
+    for t in candidates:
         if t <= last_peak:
-            t += 1
             continue
         if not universe[t]:
-            t += 1
             continue
         c0 = adj_close[t]
         if not (np.isfinite(c0) and c0 > 0):
-            t += 1
             continue
         sig = sigma[t - 1] if t >= 1 else np.nan
         if not (np.isfinite(sig) and sig > 0):
-            t += 1
             continue
         if not (np.isfinite(amt_ma[t]) and amt_ma[t] >= amt_min):
-            t += 1
             continue
         upper = c0 * (1 + h * sig)
         lower = c0 * (1 - h * sig)
@@ -98,21 +103,37 @@ def _detect_events_one_stock(
                 )
             )
             last_peak = t + upper_idx
-            t = last_peak + 1
-        else:
-            t += 1
     return events
 
 
-def detect_events_triple_barrier(panel: MarketPanel) -> list[Event]:
+def detect_events_triple_barrier(
+    panel: MarketPanel,
+    *,
+    event_idx: dict[str, np.ndarray] | None = None,
+) -> list[Event]:
+    """Detect Method C (triple-barrier) events.
+
+    Parameters
+    ----------
+    panel
+        Market panel (see `MarketPanel`).
+    event_idx
+        OPT-IN sampling restriction. When `None` (default), every eligible day
+        `t` is a candidate decision day — the original behavior, unchanged.
+        When given, a `{ts_code: array_of_indices}` mapping restricting the
+        candidate decision days per stock to the given indices (e.g. output of
+        `sampling.cusum_filter`), instead of scanning every `t`.
+    """
     events: list[Event] = []
     for j, ts_code in enumerate(panel.ts_codes):
+        stock_event_idx = None if event_idx is None else event_idx.get(ts_code)
         evs = _detect_events_one_stock(
             adj_close=panel.adj_close[:, j],
             pct_change=panel.pct_change[:, j],
             universe=panel.universe[:, j],
             amount=panel.amount[:, j],
             ts_code=ts_code,
+            event_idx=stock_event_idx,
         )
         events.extend(evs)
     return events

--- a/src/aurumq_rl/labeling/v2_excess_adaptive.py
+++ b/src/aurumq_rl/labeling/v2_excess_adaptive.py
@@ -14,13 +14,15 @@ See SPEC §2.A.
 
 from __future__ import annotations
 
+import math
+
 import numpy as np
 
 from ._common import ewm_std_1d, rolling_mean_1d
 from .events import Event
 from .panels import MarketPanel
 
-__all__ = ["detect_events_v2"]
+__all__ = ["detect_events_v2", "adaptive_threshold"]
 
 
 # Defaults from user's original v2 spec
@@ -39,6 +41,37 @@ _ewm_std = ewm_std_1d
 _rolling_mean = rolling_mean_1d
 
 
+def adaptive_threshold(vol20: float, duration: int, *, horizon_scaling: bool = False) -> float:
+    """Compute the P0 adaptive excess-return threshold `max(0.06, 1.8 * vol20)`.
+
+    GUARDRAIL (P0-locked): `horizon_scaling=False` (the default) is the exact
+    formula the P0-locked `v2_excess_adaptive` label was calibrated with — it
+    ignores `duration` entirely. This is what `detect_events_v2` uses unless
+    the caller explicitly opts in.
+
+    `horizon_scaling=True` is OPT-IN (issue #8, Part 4): it scales the vol
+    term by `sqrt(duration)`, since the vol input (`vol20`) is a *daily* EWM
+    std while the excess return it is compared against accumulates over up to
+    20 trading days with no horizon scaling — so the 0.06 floor binds almost
+    always and the label is effectively non-adaptive. Enabling this changes
+    the P0-locked label output and requires a re-ablation before production
+    use; do not flip the default.
+
+    Parameters
+    ----------
+    vol20
+        Daily EWM volatility (halflife 10) as of the decision day.
+    duration
+        Number of trading days from event start to the forward peak used to
+        realize `fwd_max_excess` (only used when `horizon_scaling=True`).
+    horizon_scaling
+        OPT-IN. Default False reproduces the P0-locked formula byte-for-byte.
+    """
+    if horizon_scaling:
+        return max(0.06, 1.8 * vol20 * math.sqrt(max(duration, 0)))
+    return max(0.06, 1.8 * vol20)
+
+
 def _detect_events_one_stock(
     adj_close: np.ndarray,
     pct_change: np.ndarray,
@@ -55,6 +88,7 @@ def _detect_events_one_stock(
     vol_halflife: float = DEFAULT_VOL_HALFLIFE,
     amt_ma_window: int = DEFAULT_AMT_MA_WINDOW,
     amt_min: float = DEFAULT_AMT_MIN,
+    horizon_scaling: bool = False,
 ) -> list[Event]:
     n = len(adj_close)
     if n < pre_window + max_duration + 2:
@@ -102,7 +136,10 @@ def _detect_events_one_stock(
         if not np.isfinite(vol20) or vol20 <= 0:
             t += 1
             continue
-        adaptive_thr = max(0.06, 1.8 * vol20)
+        # Non-scaled threshold, computed here for parity with the pre-issue-8
+        # (P0-locked) code path — this is exactly what default (horizon_scaling
+        # =False) uses below, unaffected by the eventual peak duration.
+        adaptive_thr = adaptive_threshold(vol20, duration=0, horizon_scaling=False)
         # Forward [t, t+max_duration] peak search
         end = min(n, t + max_duration + 1)
         sub = adj_close[t:end]
@@ -132,6 +169,11 @@ def _detect_events_one_stock(
         if peak_offset > max_duration:
             t += 1
             continue
+        if horizon_scaling:
+            # OPT-IN (Part 4, issue #8): rescale the vol term by sqrt(duration)
+            # now that the realized peak duration is known. Changes the
+            # P0-locked threshold — see `adaptive_threshold` docstring.
+            adaptive_thr = adaptive_threshold(vol20, duration=peak_offset, horizon_scaling=True)
         fwd_max_excess = float(excess[peak_offset])
         if fwd_max_excess < adaptive_thr:
             t += 1
@@ -162,8 +204,21 @@ def _detect_events_one_stock(
     return events
 
 
-def detect_events_v2(panel: MarketPanel) -> list[Event]:
-    """Run method A on a full MarketPanel; returns flat event list."""
+def detect_events_v2(panel: MarketPanel, *, horizon_scaling: bool = False) -> list[Event]:
+    """Run method A on a full MarketPanel; returns flat event list.
+
+    Parameters
+    ----------
+    panel
+        Market panel (see `MarketPanel`).
+    horizon_scaling
+        OPT-IN (Part 4, issue #8), default False. GUARDRAIL: `v2_excess_adaptive`
+        is the P0-locked ablation winner — `horizon_scaling=False` reproduces
+        the current P0-locked label output byte-for-byte. Setting `True`
+        scales the adaptive vol threshold by `sqrt(duration)` (see
+        `adaptive_threshold`), which changes the label and requires a
+        re-ablation before production use. Do not flip this default.
+    """
     events: list[Event] = []
     for j, ts_code in enumerate(panel.ts_codes):
         evs = _detect_events_one_stock(
@@ -173,6 +228,7 @@ def detect_events_v2(panel: MarketPanel) -> list[Event]:
             universe=panel.universe[:, j],
             benchmark_close=panel.benchmark_close,
             ts_code=ts_code,
+            horizon_scaling=horizon_scaling,
         )
         events.extend(evs)
     return events

--- a/tests/labeling/test_sampling.py
+++ b/tests/labeling/test_sampling.py
@@ -1,0 +1,197 @@
+"""Tests for CUSUM event sampling + concurrency/uniqueness weights (issue #8, Parts 1-2).
+
+López de Prado, *Advances in Financial Machine Learning* (2018):
+- ch. 2.5.2 symmetric CUSUM filter for event sampling
+- ch. 4 concurrency / average uniqueness for sample weighting
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from aurumq_rl.labeling.sampling import (
+    average_uniqueness,
+    cusum_filter,
+    label_concurrency,
+)
+
+# ---------------------------------------------------------------------------
+# Part 1 — CUSUM filter
+# ---------------------------------------------------------------------------
+
+
+def test_cusum_filter_detects_level_shifts_not_flat_stretches():
+    """A flat series with two sharp level shifts should emit events only near the shifts."""
+    series = np.concatenate(
+        [
+            np.full(20, 10.0),  # flat
+            np.full(20, 11.0),  # +10% shift at idx 20
+            np.full(20, 11.0),  # flat
+            np.full(20, 9.5),  # -13.6% shift at idx 60
+            np.full(20, 9.5),  # flat
+        ]
+    )
+    events = cusum_filter(series, threshold=0.5)
+    assert len(events) >= 1, "Should detect at least the two level shifts"
+    # No events should fire deep inside the flat stretches (far from shift boundaries)
+    flat_zone = set(range(2, 18)) | set(range(42, 58)) | set(range(82, 99))
+    assert not (set(events.tolist()) & flat_zone), (
+        f"CUSUM should not fire inside flat stretches, got {events}"
+    )
+    # Events should cluster near the two shift points (idx ~20, ~60)
+    assert any(18 <= e <= 22 for e in events), f"expected event near idx 20, got {events}"
+    assert any(58 <= e <= 62 for e in events), f"expected event near idx 60, got {events}"
+
+
+def test_cusum_filter_flat_series_no_events():
+    series = np.full(50, 10.0)
+    events = cusum_filter(series, threshold=0.5)
+    assert len(events) == 0
+
+
+def test_cusum_filter_symmetric_mirror():
+    """Mirroring the series (negating diffs) should mirror which direction fires,
+    but the event *indices* (magnitude-triggered) should be identical."""
+    rng = np.random.default_rng(7)
+    steps = rng.choice([-1.0, 1.0], size=99) * 0.3
+    series = 10.0 + np.concatenate([[0.0], np.cumsum(steps)])
+    mirrored = 20.0 - series  # negate the walk around a constant
+
+    events = cusum_filter(series, threshold=1.0)
+    events_mirrored = cusum_filter(mirrored, threshold=1.0)
+    np.testing.assert_array_equal(events, events_mirrored)
+
+
+def test_cusum_filter_threshold_zero_raises_or_no_crash_boundary():
+    # Very small threshold on a monotone series should fire many events.
+    series = np.arange(30, dtype=np.float64)
+    events = cusum_filter(series, threshold=1.0)
+    assert len(events) > 0
+    # Events should be roughly evenly spaced given a monotone unit-step walk
+    assert np.all(np.diff(events) >= 1)
+
+
+# ---------------------------------------------------------------------------
+# Part 1b — triple_barrier opt-in seeding via CUSUM/sample events
+# ---------------------------------------------------------------------------
+
+
+def test_triple_barrier_sample_events_default_unchanged():
+    """Default (event_idx=None) must reproduce the existing all-t seeding behavior."""
+    from datetime import date, timedelta
+
+    from aurumq_rl.labeling.panels import MarketPanel
+    from aurumq_rl.labeling.triple_barrier import detect_events_triple_barrier
+
+    n = 60
+    c = np.full(n, 10.0)
+    rng = np.random.default_rng(42)
+    c[1:30] = 10.0 + rng.normal(0, 0.05, size=29)
+    for i in range(30, 35):
+        c[i] = 10.0 * (1 + 0.012 * (i - 30))
+    c[35:] = c[34]
+    adj_close = c.reshape(-1, 1)
+    pct = np.diff(adj_close, axis=0, prepend=adj_close[:1]) / np.where(adj_close > 0, adj_close, 1)
+    pct[0] = 0.0
+    amount = np.full((n, 1), 5e8)
+    universe = np.ones((n, 1), dtype=bool)
+    benchmark = np.ones(n)
+    dates = [date(2024, 1, 1) + timedelta(days=i) for i in range(n)]
+    panel = MarketPanel(
+        trade_dates=dates,
+        ts_codes=["STK000"],
+        adj_close=adj_close,
+        pct_change=pct,
+        amount=amount,
+        universe=universe,
+        benchmark_close=benchmark,
+    )
+    baseline = detect_events_triple_barrier(panel)
+    with_default_kw = detect_events_triple_barrier(panel, event_idx=None)
+    assert baseline == with_default_kw
+
+
+def test_triple_barrier_sample_events_restricts_seeding():
+    """When event_idx is given, only those t are considered as candidate starts."""
+    from datetime import date, timedelta
+
+    from aurumq_rl.labeling.panels import MarketPanel
+    from aurumq_rl.labeling.triple_barrier import detect_events_triple_barrier
+
+    n = 60
+    c = np.full(n, 10.0)
+    rng = np.random.default_rng(42)
+    c[1:30] = 10.0 + rng.normal(0, 0.05, size=29)
+    for i in range(30, 35):
+        c[i] = 10.0 * (1 + 0.012 * (i - 30))
+    c[35:] = c[34]
+    adj_close = c.reshape(-1, 1)
+    pct = np.diff(adj_close, axis=0, prepend=adj_close[:1]) / np.where(adj_close > 0, adj_close, 1)
+    pct[0] = 0.0
+    amount = np.full((n, 1), 5e8)
+    universe = np.ones((n, 1), dtype=bool)
+    benchmark = np.ones(n)
+    dates = [date(2024, 1, 1) + timedelta(days=i) for i in range(n)]
+    panel = MarketPanel(
+        trade_dates=dates,
+        ts_codes=["STK000"],
+        adj_close=adj_close,
+        pct_change=pct,
+        amount=amount,
+        universe=universe,
+        benchmark_close=benchmark,
+    )
+    # Seed set that deliberately excludes the actual event start (~day 30)
+    sparse_idx = {"STK000": np.array([1, 2, 3, 4, 5], dtype=np.int64)}
+    restricted = detect_events_triple_barrier(panel, event_idx=sparse_idx)
+    assert restricted == [] or all(e.event_start_idx in sparse_idx["STK000"] for e in restricted)
+
+
+# ---------------------------------------------------------------------------
+# Part 2 — concurrency + average uniqueness
+# ---------------------------------------------------------------------------
+
+
+def test_label_concurrency_hand_computed():
+    # Two labels: [0,4] and [2,6]; a third disjoint [10,12]
+    t_starts = np.array([0, 2, 10])
+    t_ends = np.array([4, 6, 12])
+    index = np.arange(0, 13)
+    conc = label_concurrency(t_starts, t_ends, index)
+    expected = np.array(
+        [1, 1, 2, 2, 2, 1, 1, 0, 0, 0, 1, 1, 1],
+    )
+    np.testing.assert_array_equal(conc, expected)
+
+
+def test_label_concurrency_fully_non_overlapping_all_weights_equal():
+    t_starts = np.array([0, 5, 10])
+    t_ends = np.array([2, 7, 12])
+    index = np.arange(0, 13)
+    weights = average_uniqueness(t_starts, t_ends, index)
+    np.testing.assert_allclose(weights, np.ones(3))
+
+
+def test_average_uniqueness_heavy_overlap_downweighted():
+    # 3 labels all covering the same [0, 9] window → concurrency=3 everywhere → weight = 1/3 each
+    t_starts = np.array([0, 0, 0])
+    t_ends = np.array([9, 9, 9])
+    index = np.arange(0, 10)
+    weights = average_uniqueness(t_starts, t_ends, index)
+    np.testing.assert_allclose(weights, np.full(3, 1.0 / 3.0))
+    # Sanity: heavy overlap weights strictly less than the non-overlapping case
+    assert np.all(weights < 1.0)
+
+
+def test_average_uniqueness_partial_overlap_between_extremes():
+    # label 0: [0,9] fully overlapped by label1 [0,4] and label2 [5,9]
+    t_starts = np.array([0, 0, 5])
+    t_ends = np.array([9, 4, 9])
+    index = np.arange(0, 10)
+    weights = average_uniqueness(t_starts, t_ends, index)
+    # label 0 spans both halves: concurrency 2 for [0,4], 2 for [5,9] -> avg uniqueness 0.5
+    assert abs(weights[0] - 0.5) < 1e-9
+    # label 1 spans only [0,4], concurrency 2 throughout -> 0.5
+    assert abs(weights[1] - 0.5) < 1e-9
+    # label 2 spans only [5,9], concurrency 2 throughout -> 0.5
+    assert abs(weights[2] - 0.5) < 1e-9

--- a/tests/labeling/test_trend_scanning_transform.py
+++ b/tests/labeling/test_trend_scanning_transform.py
@@ -86,3 +86,16 @@ def test_tstat_transform_invalid_mode_raises():
         pass
     else:
         raise AssertionError("expected ValueError for unknown tstat_transform")
+
+
+def test_tstat_transform_invalid_mode_raises_even_with_zero_events():
+    # Eager validation: a flat panel fires no events, so a lazy per-event
+    # check would silently accept a typo'd mode. Must raise regardless.
+    flat = _make_panel(60, np.full(60, 10.0))
+    assert detect_events_trend_scanning(flat) == []
+    try:
+        detect_events_trend_scanning(flat, tstat_transform="bogus")
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("expected ValueError even when no events fire")

--- a/tests/labeling/test_trend_scanning_transform.py
+++ b/tests/labeling/test_trend_scanning_transform.py
@@ -1,0 +1,88 @@
+"""Tests for trend_scanning t-stat squashing transform (issue #8, Part 3).
+
+`tstat_transform` is opt-in; default "raw" must reproduce current output exactly.
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+import numpy as np
+
+from aurumq_rl.labeling.panels import MarketPanel
+from aurumq_rl.labeling.trend_scanning import detect_events_trend_scanning
+
+
+def _trade_dates(n: int) -> list[date]:
+    base = date(2024, 1, 1)
+    return [base + timedelta(days=i) for i in range(n)]
+
+
+def _make_panel(n_dates: int, close: np.ndarray, amount_value: float = 5e8) -> MarketPanel:
+    adj_close = close.reshape(-1, 1).astype(np.float64)
+    pct = np.diff(adj_close, axis=0, prepend=adj_close[:1]) / np.where(adj_close > 0, adj_close, 1)
+    pct[0] = 0.0
+    amount = np.full((n_dates, 1), amount_value, dtype=np.float64)
+    universe = np.ones((n_dates, 1), dtype=bool)
+    benchmark = np.ones(n_dates, dtype=np.float64)
+    return MarketPanel(
+        trade_dates=_trade_dates(n_dates),
+        ts_codes=["STK000"],
+        adj_close=adj_close,
+        pct_change=pct,
+        amount=amount,
+        universe=universe,
+        benchmark_close=benchmark,
+    )
+
+
+def _low_vol_microdrift_panel() -> MarketPanel:
+    # Extremely smooth, tiny daily drift -> huge |t-stat| (near-perfect linear fit)
+    n = 60
+    c = 10.0 * (1.0 + 0.0005 * np.arange(n))
+    return _make_panel(n, c)
+
+
+def test_tstat_transform_raw_reproduces_current_quality_exactly():
+    panel = _low_vol_microdrift_panel()
+    baseline = detect_events_trend_scanning(panel)
+    explicit_raw = detect_events_trend_scanning(panel, tstat_transform="raw")
+    assert len(baseline) == len(explicit_raw)
+    for e_base, e_raw in zip(baseline, explicit_raw, strict=True):
+        assert e_base.event_quality == e_raw.event_quality
+        assert e_base.event_start_idx == e_raw.event_start_idx
+
+
+def test_tstat_transform_tanh_compresses_high_tstat():
+    panel = _low_vol_microdrift_panel()
+    raw_events = detect_events_trend_scanning(panel, tstat_transform="raw")
+    tanh_events = detect_events_trend_scanning(panel, tstat_transform="tanh")
+    assert len(raw_events) >= 1 and len(tanh_events) >= 1
+    raw_by_start = {e.event_start_idx: e.event_quality for e in raw_events}
+    tanh_by_start = {e.event_start_idx: e.event_quality for e in tanh_events}
+    shared = set(raw_by_start) & set(tanh_by_start)
+    assert shared, "raw and tanh should fire at the same event starts"
+    for start in shared:
+        raw_q = raw_by_start[start]
+        tanh_q = tanh_by_start[start]
+        assert raw_q > 50, f"expected a very high raw t-stat on smooth micro-drift, got {raw_q}"
+        assert tanh_q < raw_q, "tanh transform must compress a large raw t-stat"
+        assert tanh_q > 0, "sign should be preserved for an up-trend"
+
+
+def test_tstat_transform_clip_caps_at_bound():
+    panel = _low_vol_microdrift_panel()
+    clipped = detect_events_trend_scanning(panel, tstat_transform="clip")
+    assert len(clipped) >= 1
+    for e in clipped:
+        assert abs(e.event_quality) <= 10.0 + 1e-9
+
+
+def test_tstat_transform_invalid_mode_raises():
+    panel = _low_vol_microdrift_panel()
+    try:
+        detect_events_trend_scanning(panel, tstat_transform="bogus")
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("expected ValueError for unknown tstat_transform")

--- a/tests/labeling/test_v2_horizon_scaling.py
+++ b/tests/labeling/test_v2_horizon_scaling.py
@@ -1,0 +1,144 @@
+"""Tests for v2_excess_adaptive √horizon vol scaling (issue #8, Part 4).
+
+GUARDRAIL: `v2_excess_adaptive` is the P0-locked ablation winner. `horizon_scaling`
+is OPT-IN and defaults to False, which MUST reproduce the current (pre-issue-8)
+label output byte-for-byte. Enabling it changes the P0-locked label and requires
+a re-ablation before production use — see module docstring in v2_excess_adaptive.py.
+"""
+
+from __future__ import annotations
+
+import math
+from datetime import date, timedelta
+
+import numpy as np
+
+from aurumq_rl.labeling.panels import MarketPanel
+from aurumq_rl.labeling.v2_excess_adaptive import adaptive_threshold, detect_events_v2
+
+
+def _trade_dates(n: int) -> list[date]:
+    base = date(2024, 1, 1)
+    return [base + timedelta(days=i) for i in range(n)]
+
+
+def _make_panel(n_dates: int, close_per_stock: list[np.ndarray], amount_value: float = 5e8):
+    n_stocks = len(close_per_stock)
+    adj_close = np.column_stack(close_per_stock).astype(np.float64)
+    pct = np.diff(adj_close, axis=0, prepend=adj_close[:1]) / np.where(adj_close > 0, adj_close, 1)
+    pct[0] = 0.0
+    amount = np.full((n_dates, n_stocks), amount_value, dtype=np.float64)
+    universe = np.ones((n_dates, n_stocks), dtype=bool)
+    benchmark = np.ones(n_dates, dtype=np.float64)
+    return MarketPanel(
+        trade_dates=_trade_dates(n_dates),
+        ts_codes=[f"STK{j:03d}" for j in range(n_stocks)],
+        adj_close=adj_close,
+        pct_change=pct,
+        amount=amount,
+        universe=universe,
+        benchmark_close=benchmark,
+    )
+
+
+def _strong_wave_panel() -> MarketPanel:
+    n = 80
+    c = np.full(n, 10.0)
+    for i in range(30, 41):
+        c[i] = 10.0 * (1 + 0.012 * (i - 29))
+    c[41:] = c[40]
+    return _make_panel(n, [c])
+
+
+# ---------------------------------------------------------------------------
+# Byte-for-byte default reproduction (P0 guardrail)
+# ---------------------------------------------------------------------------
+
+
+def test_horizon_scaling_default_false_reproduces_p0_locked_output_byte_for_byte():
+    panel = _strong_wave_panel()
+    events_no_kwarg = detect_events_v2(panel)
+    events_explicit_false = detect_events_v2(panel, horizon_scaling=False)
+
+    # Pinned exact value captured from pre-issue-8 P0-locked behavior.
+    assert len(events_no_kwarg) == 1
+    e = events_no_kwarg[0]
+    assert e.event_start_idx == 31
+    assert e.event_peak_idx == 40
+    assert e.event_quality == 1.7578125
+    assert e.event_method == "A"
+
+    assert events_no_kwarg == events_explicit_false
+
+
+def test_horizon_scaling_false_matches_existing_method_A_tests_unchanged():
+    """Re-assert the pre-existing test_method_A_* expectations still hold verbatim."""
+    panel = _strong_wave_panel()
+    events = detect_events_v2(panel)
+    assert len(events) >= 1
+    e = events[0]
+    assert 28 <= e.event_start_idx <= 31
+    assert e.event_quality > 1.0
+
+
+# ---------------------------------------------------------------------------
+# adaptive_threshold() pure-function unit tests (Part 4 formula)
+# ---------------------------------------------------------------------------
+
+
+def test_adaptive_threshold_without_scaling_ignores_duration():
+    thr_short = adaptive_threshold(vol20=0.05, duration=1, horizon_scaling=False)
+    thr_long = adaptive_threshold(vol20=0.05, duration=20, horizon_scaling=False)
+    assert thr_short == thr_long == max(0.06, 1.8 * 0.05)
+
+
+def test_adaptive_threshold_with_scaling_grows_with_sqrt_duration():
+    vol20 = 0.05
+    thr_1 = adaptive_threshold(vol20=vol20, duration=1, horizon_scaling=True)
+    thr_20 = adaptive_threshold(vol20=vol20, duration=20, horizon_scaling=True)
+    assert thr_1 == max(0.06, 1.8 * vol20 * math.sqrt(1))
+    assert thr_20 == max(0.06, 1.8 * vol20 * math.sqrt(20))
+    assert thr_20 > thr_1
+    assert thr_20 == max(0.06, 1.8 * vol20 * math.sqrt(20))
+
+
+def test_adaptive_threshold_floor_still_applies_when_scaled_term_small():
+    thr = adaptive_threshold(vol20=0.001, duration=20, horizon_scaling=True)
+    assert thr == 0.06
+
+
+# ---------------------------------------------------------------------------
+# Integration-level: horizon_scaling=True changes the threshold on a synthetic case
+# ---------------------------------------------------------------------------
+
+
+def test_horizon_scaling_true_changes_event_quality_on_synthetic_case():
+    """With enough pre-event vol, scaling the threshold by sqrt(duration) should raise
+    the bar and lower (or eliminate) the resulting event_quality vs the unscaled default.
+    """
+    n = 80
+    # Noisy but bounded pre-window (keeps 5d cumulative gain small) to get vol20 > 0.0333
+    # (so 1.8*vol20 > floor 0.06 and sqrt-duration scaling has visible effect).
+    rng = np.random.default_rng(11)
+    c = np.full(n, 10.0)
+    noise = rng.normal(0, 0.05, size=25)
+    c[1:26] = 10.0 * (1 + np.cumsum(noise) * 0.02)  # damped random walk, mild cumulative drift
+    c[26] = c[25]
+    for i in range(27, 41):
+        c[i] = c[26] * (1 + 0.015 * (i - 26))
+    c[41:] = c[40]
+    panel = _make_panel(n, [c])
+
+    events_off = detect_events_v2(panel, horizon_scaling=False)
+    events_on = detect_events_v2(panel, horizon_scaling=True)
+
+    assert len(events_off) >= 1, "Sanity: unscaled default should find the wave"
+    off_by_start = {e.event_start_idx: e for e in events_off}
+    on_by_start = {e.event_start_idx: e for e in events_on}
+
+    if set(off_by_start) & set(on_by_start):
+        for start in set(off_by_start) & set(on_by_start):
+            assert on_by_start[start].event_quality <= off_by_start[start].event_quality
+    else:
+        # Threshold scaling rejected the event entirely under horizon_scaling=True.
+        assert len(events_on) < len(events_off)


### PR DESCRIPTION
Closes #8.

Four **additive, opt-in** López de Prado alignments to `src/aurumq_rl/labeling/`. Guardrail respected: `v2_excess_adaptive` (P0-locked ablation winner) default output unchanged; all 3 pre-existing labeling test files byte-identical to main; defaults reproduce current output byte-for-byte (independently verified in review + a fresh `pytest tests/labeling/` run).

## 1. CUSUM event sampling
Symmetric LdP CUSUM filter (`labeling/sampling.py`); triple_barrier gains opt-in `event_idx` seeding (default all-`t` unchanged). Seeds events instead of clustering in autocorrelated stretches.

## 2. Sample concurrency / uniqueness weights
`label_concurrency` / `average_uniqueness` (new utilities) → per-label `sample_weight` for LightGBM, so overlapping-outcome labels aren't over-weighted (LdP ch. 4). Boundary conventions hand-verified.

## 3. trend_scanning t-stat squashing (opt-in)
`tstat_transform: {"raw","tanh","clip"}` (default `"raw"` = current unbounded quality). Bounds low-vol micro-drift t-stats so they no longer dominate `search_threshold`; selection/direction always use the raw t-stat. **Eager-validated** (a typo'd mode raises immediately, even on a zero-event run — review Minor, fixed with a test a lazy check couldn't catch).

## 4. v2_excess_adaptive √horizon scaling (opt-in, P0-locked)
`horizon_scaling: bool = False` (default = exact P0-locked behavior, pinned byte-for-byte). When True, scales the vol term by √duration so the 6% floor stops binding always. Docstring warns loudly that enabling requires re-ablation.

## Tests
+21 tests (CUSUM shifts/symmetry, hand-computed concurrency, raw-vs-tanh compression + eager-validation, v2_excess byte-for-byte default + scaled path). Suite 1666 passed. CI gates green locally (ruff check/format, pytest, smoke `status=ok`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)