### PR TITLE
feat(factors): opt-in incremental computation protocol (closes #10)

### DIFF
--- a/src/aurumq_rl/factors/alpha101/momentum.py
+++ b/src/aurumq_rl/factors/alpha101/momentum.py
@@ -156,6 +156,68 @@ def alpha009(panel: pl.DataFrame) -> pl.Series:
 
 
 # ---------------------------------------------------------------------------
+# alpha009 — incremental path (reference implementation, issue #10)
+# ---------------------------------------------------------------------------
+
+ALPHA009_MAX_WINDOW: int = 5
+"""Maximum lookback (in prior rows) alpha009 needs before its first row.
+
+``delta(close, 1)`` needs 1 prior row; ``ts_min``/``ts_max`` of that delta
+over a 5-row window then need 5 consecutive delta values, i.e. 5 prior
+``close`` rows (rows ``t-5 .. t-1``) before row ``t`` is fully warmed up.
+Combined with the 1-row delta lag this is still 5 — the delta lag is
+already "inside" the 5-row delta window, not additive on top of it.
+"""
+
+
+def alpha009_incremental(tail_df: pl.DataFrame, n_new: int) -> pl.Series:
+    """Incremental counterpart of :func:`alpha009` (issue #10 reference impl).
+
+    Contract (see ``aurumq_rl.factors.registry`` module docstring for the
+    general protocol)
+    -----------------------------------------------------------------------
+    ``tail_df`` must be sorted ``[stock_code, trade_date]`` ascending and
+    contain, for every stock present in its last ``n_new`` rows, at least
+    ``ALPHA009_MAX_WINDOW + n_new`` rows for that stock (``ALPHA009_MAX_WINDOW``
+    rows of prior history immediately followed by the ``n_new`` new rows).
+
+    Returns the alpha009 value for exactly the last ``n_new`` rows of every
+    stock group in ``tail_df``, in the same per-stock grouped order as those
+    trailing rows. Because alpha009 is a pure per-stock time-series formula
+    with no cross-sectional dependency (unlike most alpha101 factors, it
+    never calls ``cs_rank``), recomputing it on a bounded tail buffer is
+    numerically identical to recomputing it on the full history and slicing
+    the same trailing rows — the rolling windows only ever look backward
+    within one stock, and the buffer supplies every row those windows need.
+
+    Raises ``ValueError`` (naming the offending stock(s)) if any stock in
+    ``tail_df`` has fewer than ``ALPHA009_MAX_WINDOW + n_new`` rows —
+    silently returning under-warmed values is not acceptable for a daily
+    refresh path. Also raises ``ValueError`` if ``n_new < 1``.
+
+    Required panel columns: ``close``, ``stock_code``, ``trade_date``.
+    """
+    if n_new < 1:
+        raise ValueError(f"n_new must be >= 1, got {n_new}")
+
+    min_required = ALPHA009_MAX_WINDOW + n_new
+    counts = tail_df.group_by("stock_code").len()
+    too_short = counts.filter(pl.col("len") < min_required)
+    if too_short.height > 0:
+        bad = sorted(too_short["stock_code"].to_list())
+        raise ValueError(
+            f"alpha009_incremental: tail buffer too short for stock(s) {bad} — "
+            f"need >= max_window({ALPHA009_MAX_WINDOW}) + n_new({n_new}) = "
+            f"{min_required} rows per stock, got fewer"
+        )
+
+    values = alpha009(tail_df)
+    tagged = tail_df.select("stock_code").with_columns(values.alias("__a009_incr"))
+    tail_only = tagged.group_by("stock_code", maintain_order=True).tail(n_new)
+    return tail_only["__a009_incr"].rename("alpha009").cast(pl.Float64)
+
+
+# ---------------------------------------------------------------------------
 # alpha010 — Cross-sectional rank of trend-confirmed price change
 # ---------------------------------------------------------------------------
 
@@ -657,6 +719,10 @@ _ENTRIES = [
         ),
         references=("Kakushadze 2015, '101 Formulaic Alphas', arXiv:1601.00991, eq. 9",),
         formula_doc_path="docs/factor_library/alpha101/alpha_009.md",
+        # Reference implementation of the OPT-IN incremental-computation
+        # protocol (issue #10) — see alpha009_incremental's docstring.
+        impl_incremental=alpha009_incremental,
+        max_window=ALPHA009_MAX_WINDOW,
     ),
     FactorEntry(
         id="alpha010",

--- a/src/aurumq_rl/factors/registry.py
+++ b/src/aurumq_rl/factors/registry.py
@@ -23,6 +23,51 @@ Design notes
   once parity is verified.
 * ``quality_flag``: ``0`` = ok, ``1`` = errata-conservative (gtja191
   ambiguous formulas), ``2`` = stub.
+* ``impl_incremental`` / ``max_window``: OPTIONAL opt-in fields (both default
+  ``None``) implementing the incremental-computation protocol — see the
+  "Incremental computation protocol" section below. A factor that does not
+  set them behaves exactly as before (``impl`` is the only required path).
+
+Incremental computation protocol (issue #10)
+---------------------------------------------
+Every registered factor keeps its full-history path: ``impl(df) -> pl.Series``
+recomputes the factor over the entire panel and remains the source of truth.
+Some factors — pure per-stock time-series formulas with a bounded rolling
+lookback — can ALSO opt into a second, optional path meant for a daily
+refresh: recompute only the new rows using a bounded "tail buffer" per stock
+instead of replaying the full history.
+
+A factor opts in by registering two additional fields on ``FactorEntry``:
+
+* ``max_window: int`` — the factor's maximum lookback in rows (the deepest
+  rolling window / delay it uses, expressed as "how many prior rows are
+  needed before the first row a caller cares about can be computed").
+* ``impl_incremental: Callable[[pl.DataFrame, int], pl.Series]`` — given a
+  **tail buffer** ``tail_df`` and an integer ``n_new``, returns the factor
+  values for exactly the last ``n_new`` rows of every stock group in
+  ``tail_df``.
+
+Tail buffer contract
+~~~~~~~~~~~~~~~~~~~~~
+``tail_df`` must be sorted ``[stock_code, trade_date]`` ascending (same
+convention as the full-history panel passed to ``impl``) and must contain,
+for every stock present in its last ``n_new`` rows, **at least**
+``max_window + n_new`` rows for that stock — i.e. ``max_window`` rows of
+prior history immediately followed by the ``n_new`` new rows. A caller
+assembles this by taking, per stock, the last ``max_window + n_new`` rows of
+that stock's full history (see :func:`compute_incremental` for a ready-made
+slicer over a full panel).
+
+Given a buffer that satisfies the contract, ``impl_incremental(tail_df,
+n_new)`` MUST return a ``pl.Series`` of length ``n_new * n_stocks`` (in the
+same per-stock grouped order as ``tail_df``'s trailing rows) that is
+numerically identical, within float tolerance, to slicing
+``impl(full_history_df)`` down to those same trailing ``n_new`` rows per
+stock. A conforming implementation may reject a buffer shorter than the
+minimum with a clear ``ValueError`` naming the offending stock(s); silently
+returning wrong numbers is never acceptable. Registered ``impl_incremental``
+callables are auto-wrapped with :func:`sanitize_factor_series`, exactly like
+``impl``, so both paths apply the same inf/overflow cleanup.
 """
 
 from __future__ import annotations
@@ -36,8 +81,10 @@ if TYPE_CHECKING:
     import polars as pl
 
     FactorImpl = Callable[["pl.DataFrame"], "pl.Series"]
+    FactorImplIncremental = Callable[["pl.DataFrame", int], "pl.Series"]
 else:
     FactorImpl = Callable
+    FactorImplIncremental = Callable
 
 
 __all__ = [
@@ -49,6 +96,8 @@ __all__ = [
     "register_alpha101",
     "register_gtja191",
     "resolve_for_aqml",
+    "resolve_incremental",
+    "compute_incremental",
     "sanitize_factor_series",
 ]
 
@@ -98,9 +147,34 @@ def _wrap_impl_with_sanitizer(impl: FactorImpl) -> FactorImpl:
     return _sanitized
 
 
+def _wrap_impl_incremental_with_sanitizer(
+    impl_incremental: FactorImplIncremental,
+) -> FactorImplIncremental:
+    """Wrap ``impl_incremental(tail_df, n_new) -> pl.Series`` with the sanitizer.
+
+    Mirrors :func:`_wrap_impl_with_sanitizer` so the incremental path applies
+    the exact same inf/overflow cleanup as the full-history path — required
+    for the two paths to stay numerically identical (see module docstring).
+    """
+
+    def _sanitized(tail_df, n_new):  # type: ignore[no-untyped-def]
+        return sanitize_factor_series(impl_incremental(tail_df, n_new))
+
+    _sanitized.__name__ = getattr(impl_incremental, "__name__", "_sanitized_impl_incremental")
+    _sanitized.__doc__ = getattr(impl_incremental, "__doc__", None)
+    _sanitized.__wrapped__ = impl_incremental  # type: ignore[attr-defined]
+    return _sanitized
+
+
 @dataclass(frozen=True)
 class FactorEntry:
-    """Metadata + callable for a single factor."""
+    """Metadata + callable for a single factor.
+
+    ``impl_incremental`` / ``max_window`` are OPTIONAL (default ``None``) —
+    see the "Incremental computation protocol" section of the module
+    docstring. A factor that leaves them unset is unaffected; ``impl`` and
+    the full-history recompute path are always available and unchanged.
+    """
 
     id: str
     impl: FactorImpl
@@ -111,10 +185,26 @@ class FactorEntry:
     quality_flag: int = 0
     references: tuple[str, ...] = field(default_factory=tuple)
     formula_doc_path: str = ""
+    impl_incremental: FactorImplIncremental | None = None
+    max_window: int | None = None
 
 
 ALPHA101_REGISTRY: dict[str, FactorEntry] = {}
 GTJA191_REGISTRY: dict[str, FactorEntry] = {}
+
+
+def _validate_incremental_metadata(entry: FactorEntry) -> None:
+    """Enforce that ``impl_incremental`` and ``max_window`` are set together.
+
+    ``max_window`` is only required for factors that provide
+    ``impl_incremental`` (see module docstring); it stays optional
+    otherwise, so this never rejects the ~99% of factors that don't opt in.
+    """
+    if entry.impl_incremental is not None and entry.max_window is None:
+        raise ValueError(
+            f"factor {entry.id!r} provides impl_incremental but no max_window "
+            "— max_window is required whenever impl_incremental is set"
+        )
 
 
 def register_alpha101(entry: FactorEntry) -> FactorEntry:
@@ -122,9 +212,20 @@ def register_alpha101(entry: FactorEntry) -> FactorEntry:
 
     The entry's ``impl`` is automatically wrapped with :func:`sanitize_factor_series`
     so every registered factor produces inf-free, clipped output regardless of how
-    the underlying formula handles divide-by-zero / overflow.
+    the underlying formula handles divide-by-zero / overflow. If ``impl_incremental``
+    is set, it is wrapped the same way (see module docstring for the protocol).
     """
-    sanitized_entry = dataclasses.replace(entry, impl=_wrap_impl_with_sanitizer(entry.impl))
+    _validate_incremental_metadata(entry)
+    wrapped_incremental = (
+        _wrap_impl_incremental_with_sanitizer(entry.impl_incremental)
+        if entry.impl_incremental is not None
+        else None
+    )
+    sanitized_entry = dataclasses.replace(
+        entry,
+        impl=_wrap_impl_with_sanitizer(entry.impl),
+        impl_incremental=wrapped_incremental,
+    )
     if entry.id in ALPHA101_REGISTRY and ALPHA101_REGISTRY[entry.id] is not sanitized_entry:
         # Allow re-registration only if the underlying (unwrapped) impl is identical.
         existing_impl = getattr(
@@ -141,9 +242,20 @@ def register_alpha101(entry: FactorEntry) -> FactorEntry:
 def register_gtja191(entry: FactorEntry) -> FactorEntry:
     """Register a factor in the gtja191 registry (idempotent on identical entry).
 
-    See :func:`register_alpha101` for the auto-sanitization contract.
+    See :func:`register_alpha101` for the auto-sanitization contract (applies
+    identically to ``impl_incremental`` when set).
     """
-    sanitized_entry = dataclasses.replace(entry, impl=_wrap_impl_with_sanitizer(entry.impl))
+    _validate_incremental_metadata(entry)
+    wrapped_incremental = (
+        _wrap_impl_incremental_with_sanitizer(entry.impl_incremental)
+        if entry.impl_incremental is not None
+        else None
+    )
+    sanitized_entry = dataclasses.replace(
+        entry,
+        impl=_wrap_impl_with_sanitizer(entry.impl),
+        impl_incremental=wrapped_incremental,
+    )
     if entry.id in GTJA191_REGISTRY and GTJA191_REGISTRY[entry.id] is not sanitized_entry:
         existing_impl = getattr(
             GTJA191_REGISTRY[entry.id].impl, "__wrapped__", GTJA191_REGISTRY[entry.id].impl
@@ -196,3 +308,99 @@ def resolve_for_aqml(name: str, df: pl.DataFrame) -> pl.Series:
         raise KeyError(name)
     entry = factors[name]
     return entry.impl(df)
+
+
+def resolve_incremental(name: str, tail_df: pl.DataFrame, n_new: int) -> pl.Series:
+    """Incremental counterpart of :func:`resolve_for_aqml`.
+
+    Looks up ``name`` in the merged registry and invokes its
+    ``impl_incremental(tail_df, n_new)``. See the module docstring's
+    "Incremental computation protocol" section for the tail-buffer contract
+    ``tail_df`` must satisfy.
+
+    Parameters
+    ----------
+    name :
+        Factor id, e.g. ``"alpha009"``.
+    tail_df :
+        Per-stock tail buffer: >= ``max_window + n_new`` rows per stock,
+        sorted ``[stock_code, trade_date]`` ascending.
+    n_new :
+        Number of new (trailing) rows per stock to compute.
+
+    Returns
+    -------
+    pl.Series
+        Factor values for the last ``n_new`` rows of every stock group in
+        ``tail_df``.
+
+    Raises
+    ------
+    KeyError
+        If ``name`` is not in any registry.
+    ValueError
+        If the factor is registered but does not provide
+        ``impl_incremental`` (i.e. has not opted into the protocol).
+    """
+    factors = list_all_factors()
+    if name not in factors:
+        raise KeyError(name)
+    entry = factors[name]
+    if entry.impl_incremental is None:
+        raise ValueError(
+            f"factor {name!r} has no incremental implementation "
+            "(impl_incremental is None) — use resolve_for_aqml / impl instead"
+        )
+    return entry.impl_incremental(tail_df, n_new)
+
+
+def compute_incremental(entry: FactorEntry, panel: pl.DataFrame, n_new: int) -> pl.Series:
+    """Slice the per-stock tail buffer from a full panel and run the incremental path.
+
+    Convenience helper so callers don't have to hand-roll the "last
+    ``max_window + n_new`` rows per stock" slice documented in the module's
+    "Incremental computation protocol" section. ``panel`` should be the same
+    full-history frame that would otherwise be passed to ``entry.impl`` —
+    this helper only reads the trailing rows it needs per stock, so it stays
+    ``O(n_stocks * (max_window + n_new))`` regardless of ``panel``'s total
+    length.
+
+    Parameters
+    ----------
+    entry :
+        A :class:`FactorEntry` with both ``impl_incremental`` and
+        ``max_window`` set (i.e. one that opted into the protocol).
+    panel :
+        Full-history panel, sorted ``[stock_code, trade_date]`` ascending.
+        May contain more history than needed — only the tail is read.
+    n_new :
+        Number of new (trailing) rows per stock to compute.
+
+    Returns
+    -------
+    pl.Series
+        Same as calling ``entry.impl_incremental`` directly on the sliced
+        tail buffer.
+
+    Raises
+    ------
+    ValueError
+        If ``entry`` did not register ``impl_incremental`` / ``max_window``,
+        or if any stock present in the trailing ``n_new`` rows has fewer
+        than ``max_window + n_new`` rows of history available in ``panel``
+        (surfaced by the underlying ``impl_incremental`` call).
+    """
+    if entry.impl_incremental is None or entry.max_window is None:
+        raise ValueError(
+            f"factor {entry.id!r} does not support incremental computation "
+            "(impl_incremental / max_window not set)"
+        )
+    if n_new < 1:
+        raise ValueError(f"n_new must be >= 1, got {n_new}")
+    buffer_size = entry.max_window + n_new
+    tail_df = (
+        panel.sort(["stock_code", "trade_date"])
+        .group_by("stock_code", maintain_order=True)
+        .tail(buffer_size)
+    )
+    return entry.impl_incremental(tail_df, n_new)

--- a/tests/factors/test_incremental.py
+++ b/tests/factors/test_incremental.py
@@ -1,0 +1,220 @@
+"""Tests for the OPT-IN incremental factor computation protocol (issue #10).
+
+Correctness crux: ``impl_incremental(tail_buffer, n_new)`` must reproduce
+exactly what ``impl(full_df)`` would produce for the last ``n_new`` rows of
+every stock, using only a bounded per-stock tail buffer instead of the full
+panel history. See ``FactorEntry`` / ``compute_incremental`` docstrings in
+``aurumq_rl.factors.registry`` for the precise contract.
+
+All data here is synthetic (the shared ``synthetic_panel`` fixture, or small
+hand-built frames for the isolation/error-path tests) — no real market data.
+"""
+
+from __future__ import annotations
+
+import polars as pl
+import pytest
+
+from aurumq_rl.factors import registry
+from aurumq_rl.factors.alpha101.momentum import (
+    ALPHA009_MAX_WINDOW,
+    alpha009,
+    alpha009_incremental,
+)
+
+
+def _tail_buffer(panel: pl.DataFrame, n_new: int, max_window: int) -> pl.DataFrame:
+    """Slice the last ``max_window + n_new`` rows per stock from ``panel``.
+
+    Mirrors what a caller of the incremental protocol is expected to
+    assemble by hand (used here so the correctness test is independent of
+    the ``compute_incremental`` helper under test elsewhere).
+    """
+    buffer_size = max_window + n_new
+    return (
+        panel.sort(["stock_code", "trade_date"])
+        .group_by("stock_code", maintain_order=True)
+        .tail(buffer_size)
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. Correctness (the crux)
+# ---------------------------------------------------------------------------
+
+
+class TestAlpha009IncrementalCorrectness:
+    @pytest.mark.parametrize("n_new", [1, 2, 5])
+    def test_matches_full_recompute_tail(self, synthetic_panel, n_new):
+        full = alpha009(synthetic_panel)
+        full_tagged = synthetic_panel.select(["stock_code", "trade_date"]).with_columns(
+            full.alias("alpha009")
+        )
+        expected = (
+            full_tagged.sort(["stock_code", "trade_date"])
+            .group_by("stock_code", maintain_order=True)
+            .tail(n_new)
+        )
+
+        tail_buf = _tail_buffer(synthetic_panel, n_new, ALPHA009_MAX_WINDOW)
+        got = alpha009_incremental(tail_buf, n_new)
+
+        assert len(got) == len(expected)
+        got_list = got.to_list()
+        expected_list = expected["alpha009"].to_list()
+        assert len(got_list) == len(expected_list)
+        for g, e in zip(got_list, expected_list, strict=True):
+            if e is None:
+                assert g is None
+            else:
+                assert g == pytest.approx(e, rel=1e-9, abs=1e-9)
+
+    def test_multiple_stocks_all_covered(self, synthetic_panel):
+        n_new = 3
+        tail_buf = _tail_buffer(synthetic_panel, n_new, ALPHA009_MAX_WINDOW)
+        got = alpha009_incremental(tail_buf, n_new)
+        n_stocks = synthetic_panel["stock_code"].n_unique()
+        assert len(got) == n_stocks * n_new
+
+
+# ---------------------------------------------------------------------------
+# 2. Insufficient buffer
+# ---------------------------------------------------------------------------
+
+
+class TestInsufficientBuffer:
+    def test_short_buffer_raises_clear_error(self, synthetic_panel):
+        n_new = 3
+        # One row short of the documented minimum (max_window + n_new).
+        short_buf = _tail_buffer(synthetic_panel, n_new, ALPHA009_MAX_WINDOW - 1)
+        with pytest.raises(ValueError, match="tail buffer too short"):
+            alpha009_incremental(short_buf, n_new)
+
+    def test_error_message_names_offending_stock(self, synthetic_panel):
+        n_new = 2
+        buf = _tail_buffer(synthetic_panel, n_new, ALPHA009_MAX_WINDOW)
+        # Truncate just one stock's rows below the minimum to simulate a
+        # partial/short history for a single ticker.
+        one_stock = buf["stock_code"][0]
+        short_rows = buf.filter(pl.col("stock_code") == one_stock).tail(
+            ALPHA009_MAX_WINDOW + n_new - 1
+        )
+        other_rows = buf.filter(pl.col("stock_code") != one_stock)
+        mixed = pl.concat([short_rows, other_rows]).sort(["stock_code", "trade_date"])
+        with pytest.raises(ValueError, match=one_stock):
+            alpha009_incremental(mixed, n_new)
+
+    def test_n_new_must_be_positive(self, synthetic_panel):
+        buf = _tail_buffer(synthetic_panel, 1, ALPHA009_MAX_WINDOW)
+        with pytest.raises(ValueError, match="n_new"):
+            alpha009_incremental(buf, 0)
+
+
+# ---------------------------------------------------------------------------
+# 3. Registry metadata
+# ---------------------------------------------------------------------------
+
+
+class TestRegistryMetadata:
+    def test_alpha009_reports_incremental_available(self):
+        entry = registry.ALPHA101_REGISTRY["alpha009"]
+        assert entry.impl_incremental is not None
+        assert entry.max_window == ALPHA009_MAX_WINDOW
+
+    def test_factor_without_incremental_reports_unavailable(self):
+        entry = registry.ALPHA101_REGISTRY["alpha007"]
+        assert entry.impl_incremental is None
+
+    def test_no_other_factor_gained_incremental_support(self):
+        """Additive-only guardrail: only alpha009 opts into the new protocol."""
+        merged = registry.list_all_factors()
+        for fid, entry in merged.items():
+            if fid == "alpha009":
+                continue
+            assert entry.impl_incremental is None, f"{fid} unexpectedly has impl_incremental"
+            assert entry.max_window is None, f"{fid} unexpectedly has max_window"
+
+    def test_resolve_incremental_invokes_impl(self, synthetic_panel):
+        n_new = 2
+        tail_buf = _tail_buffer(synthetic_panel, n_new, ALPHA009_MAX_WINDOW)
+        out = registry.resolve_incremental("alpha009", tail_buf, n_new)
+        direct = alpha009_incremental(tail_buf, n_new)
+        assert out.to_list() == pytest.approx(direct.to_list(), nan_ok=True)
+
+    def test_resolve_incremental_unavailable_raises(self, synthetic_panel):
+        buf = synthetic_panel.head(5)
+        with pytest.raises(ValueError, match="no incremental implementation"):
+            registry.resolve_incremental("alpha007", buf, 1)
+
+    def test_resolve_incremental_unknown_symbol_raises_keyerror(self, synthetic_panel):
+        buf = synthetic_panel.head(5)
+        with pytest.raises(KeyError, match="alpha999"):
+            registry.resolve_incremental("alpha999", buf, 1)
+
+
+# ---------------------------------------------------------------------------
+# 4. Multi-stock isolation
+# ---------------------------------------------------------------------------
+
+
+class TestMultiStockIsolation:
+    def _two_stock_panel(self) -> pl.DataFrame:
+        import datetime as dt
+
+        n_days = 12
+        dates = [dt.date(2024, 1, 2) + dt.timedelta(days=i) for i in range(n_days)]
+        # Stock A: strictly increasing close (persistent uptrend).
+        close_a = [10.0 + i for i in range(n_days)]
+        # Stock B: strictly decreasing close (persistent downtrend) — a very
+        # different regime so cross-stock leakage would visibly perturb the
+        # trend-confirmation branches in alpha009.
+        close_b = [50.0 - 2 * i for i in range(n_days)]
+
+        rows = []
+        for i in range(n_days):
+            rows.append({"stock_code": "AAA", "trade_date": dates[i], "close": close_a[i]})
+        for i in range(n_days):
+            rows.append({"stock_code": "BBB", "trade_date": dates[i], "close": close_b[i]})
+        return pl.DataFrame(rows).sort(["stock_code", "trade_date"])
+
+    def test_stock_a_does_not_leak_into_stock_b(self):
+        panel = self._two_stock_panel()
+        n_new = 2
+        full = alpha009(panel)
+        full_tagged = panel.select(["stock_code", "trade_date"]).with_columns(
+            full.alias("alpha009")
+        )
+        expected = (
+            full_tagged.sort(["stock_code", "trade_date"])
+            .group_by("stock_code", maintain_order=True)
+            .tail(n_new)
+        )
+
+        tail_buf = _tail_buffer(panel, n_new, ALPHA009_MAX_WINDOW)
+        got = alpha009_incremental(tail_buf, n_new)
+        new_rows = tail_buf.group_by("stock_code", maintain_order=True).tail(n_new)
+        got_tagged = new_rows.select("stock_code").with_columns(got.alias("alpha009"))
+
+        for stock in ("AAA", "BBB"):
+            exp_vals = expected.filter(pl.col("stock_code") == stock)["alpha009"].to_list()
+            got_vals = got_tagged.filter(pl.col("stock_code") == stock)["alpha009"].to_list()
+            assert got_vals == pytest.approx(exp_vals, rel=1e-9, abs=1e-9)
+
+        # Sanity: the two regimes must actually diverge (else the isolation
+        # check above would pass vacuously).
+        aaa_vals = got_tagged.filter(pl.col("stock_code") == "AAA")["alpha009"].to_list()
+        bbb_vals = got_tagged.filter(pl.col("stock_code") == "BBB")["alpha009"].to_list()
+        assert aaa_vals != bbb_vals
+
+    def test_buffer_row_order_within_group_preserved(self):
+        """Output order matches the trailing rows of the tail buffer per stock."""
+        panel = self._two_stock_panel()
+        n_new = 3
+        tail_buf = _tail_buffer(panel, n_new, ALPHA009_MAX_WINDOW)
+        got = alpha009_incremental(tail_buf, n_new)
+        new_rows = tail_buf.group_by("stock_code", maintain_order=True).tail(n_new)
+        got_tagged = new_rows.select(["stock_code", "trade_date"]).with_columns(got.alias("v"))
+        # Within each stock, dates must be strictly increasing (no shuffling).
+        for stock in ("AAA", "BBB"):
+            dates = got_tagged.filter(pl.col("stock_code") == stock)["trade_date"].to_list()
+            assert dates == sorted(dates)


### PR DESCRIPTION
Closes #10.

Opt-in **incremental factor computation protocol** so a daily refresh recomputes only new rows instead of full history (O(stocks × max_window) vs O(full panel)). Additive-only — no existing `impl(df)->Series` path or factor output changes (registry-wide test asserts every factor except the reference still has `impl_incremental is None`; all 302 `FactorEntry` call sites are keyword-based so the two new trailing fields break nothing).

## Protocol
- `FactorEntry` gains optional `impl_incremental` + `max_window` (both default None, validated together).
- Contract (documented): given a tail buffer of ≥ `max_window + n_new` rows per stock (sorted `[stock, date]`), `impl_incremental(tail_df, n_new)` returns the factor for exactly the last `n_new` rows per stock, numerically identical to `impl(full_df)` on those rows.
- `compute_incremental(entry, panel, n_new)` helper does the tail-slice + dispatch.
- Reference: `alpha009_incremental` (`max_window=5`).

## Verified in review
The correctness test is a genuine equality check (`rel=abs=1e-9`): `max_window=5` gives zero mismatches across n_new ∈ {1,2,3,5,10} × 10 stocks, while `max_window≤4` produces real divergences (under-warmed rolling window hits the null→otherwise branch) — so the window size is provably exact, and isolation is non-vacuous (divergent-regime stocks assert-differ).

## Tests
+15 tests (`tests/factors/test_incremental.py`): correctness across n_new, insufficient-buffer raise (names the stock), registry metadata + full-registry regression guard, multi-stock isolation. Suite 1660 passed. CI gates green locally (ruff check/format, pytest, smoke `status=ok`). Not wired into training/eval (protocol + reference + tests only, per issue scope).

## Minor follow-ups (non-blocking, from review)
- `alpha009_incremental` row-count guard checks all stocks in the buffer vs the docstring's "stocks in last n_new rows" — tighten docstring or scope.
- `compute_incremental` re-sorts the full panel (O(panel)); fine now (not on a hot path), harden if wired into training.
- A `cs_rank`-based factor would need a richer per-date buffer contract if opted in later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)