### PR TITLE
feat(p3): MASTER-lite 预注册协议落地 — 成本否决 + 3窗3seed + 模型层修正 (§12.7d)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,31 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+
+AurumQ-RL is a Python 3.10+ package with source code in `src/aurumq_rl/`. Core modules cover data loading, Gymnasium-style environments, reward functions, backtesting, metrics, ONNX inference, and factor registries. CLI entry points live in `scripts/`, examples in `examples/`, and documentation in `docs/`. Tests are under `tests/`, with factor-specific coverage in `tests/factors/`. Demo data and schema notes are in `data/`. The dashboard is a separate Next.js app in `web/`; follow `web/AGENTS.md` before editing that subtree.
+
+## Build, Test, and Development Commands
+
+- `python3 -m venv .venv && source .venv/bin/activate`: create a local virtual environment.
+- `pip install -e ".[dev]"`: install core package plus test, lint, and type-check tools.
+- `pip install -e ".[dev,train]"`: add training dependencies for GPU-capable environments.
+- `pytest tests/ -v --tb=short`: run the full Python test suite.
+- `pytest tests/ -v -k smoke`: run the CPU-safe smoke path.
+- `ruff check src tests scripts` and `ruff format src tests scripts`: lint and format Python code.
+- `bash scripts/web_dashboard.sh`: install and run the local dashboard at `http://localhost:3000`.
+
+## Coding Style & Naming Conventions
+
+Use 4-space indentation, type hints on public APIs, and docstrings for public functions/classes. Ruff is configured in `pyproject.toml` with a 100-character line length and Python 3.10 target. Keep the import package name `aurumq_rl`; do not introduce `aurumq.*` imports. Factor columns are discovered by prefixes such as `alpha_*`, `mf_*`, `hm_*`, and `gtja_*`; preserve these contracts when changing loaders or docs.
+
+## Testing Guidelines
+
+Tests use `pytest` with files named `test_*.py` and functions named `test_*`. Use markers already defined in `pyproject.toml`, including `smoke`, `factors`, `env`, and `slow`. Add focused tests for new behavior and aim for at least 80% coverage on new code: `pytest tests/ -v --cov=src/aurumq_rl`.
+
+## Commit & Pull Request Guidelines
+
+Recent history uses conventional commits, for example `feat(data): ...`, `fix(backtest): ...`, and `chore: ...`. Prefer branches like `feat/your-change`. PRs should describe intent, list tests run, link relevant issues, and include screenshots for dashboard UI changes.
+
+## Security & Configuration Tips
+
+Do not commit API keys, tokens, internal URLs, commercial data-source details, or real A-share datasets. `data/synthetic_demo.parquet` must remain synthetic. Keep core inference dependencies lightweight; PyTorch, Stable-Baselines3, Gymnasium, and W&B belong behind optional training extras.

--- a/README.md
+++ b/README.md
@@ -1510,8 +1510,9 @@ bash scripts/web_dashboard.sh        # macOS / Linux / Git Bash
 **2026-07-17 更新（4070 重新启用，详细依据见 §12.7）**：
 
 - [ ] **MASTER-lite bring-up**：`scripts/p3/master_train.py` CPU smoke（`--device cpu --max-stocks 200`）→ 4070 全量训练 → `master_ensemble_eval.py` 出 KEEP/KILL verdict（对 path5_long base）
+  - 预注册协议（2026-07-17，训练前锁定）：**3 seeds (42/43/44) rank 平均后再 blend**（Phase 17/18 种子鲁棒性纪律）；**eval 窗口 = H1 + H2 + W3(2026-01-05~2026-06-30)**，避免双窗 2/2 全胜制退化；verdict 含 §12.7d 成本否决（见下）
 - [ ] **Kronos 系列适用 kill criteria**：v13 之后不再排独立预测/微调实验，只保留 embedding-as-feature 消融（§12.7a）
-- [ ] **cost-adjusted 评估落地**：年化双边换手 + 分档红利税进 cell 报告模板（§12.7d）
+- [x] **cost-adjusted 评估落地**（2026-07-17 代码层完成）：`master_lib.COST_SPEC_V1`（佣金 2.5bps/边 + 印花税 5bps 卖方 + 冲击 10bps/边 + 红利税近似 40bps/年 pro-rata）；`cost_metric_block` 输出年化双边换手 + net-of-cost top-K 超额；`kill_criteria_verdict(cost_key=...)` 对「IC 赢但净值输」的窗口直接否决（§12.7d）。注：分档红利税的 per-lot FIFO 精确实现需要 bundle 携带分红事件数据，v1 先用预注册近似，升级时 bump COST_SPEC_V2 重跑
 
 **2026-07-17 update (4070 re-enabled; rationale in §12.7).** MASTER-lite bring-up (CPU smoke → full 4070 train → KEEP/KILL verdict vs the path5_long base); Kronos track restricted to embedding-as-feature ablations under the pre-registered kill criteria; cost-adjusted metrics (turnover + tiered dividend tax) added to the cell-report template.
 
@@ -1769,6 +1770,8 @@ A 股选股 ML 研究归两大 paradigm:
 **中文.** 1-5 日 horizon 的信号密度最高，但 A股 T+1 + 印花税 + **按持股期限分档的红利税**（≤1 月 20% / 1 月-1 年 10% / >1 年免——周频调仓的 top-K 正是 20% 档重灾区）意味着日频 IC 0.05 级别的信号扣双边成本后利润很薄；国盛证据显示短周期量价 alpha 自 2024 年起拥挤衰减。**修正**：后续每个 cell 报告须附年化双边换手与 cost-adjusted 指标（参考 rqalpha 6.2.0 的 `_pay_dividend_tax` per-lot FIFO 实现，`rqalpha_mod_sys_accounts/position_model.py:322`）；「IC 好看但净值不赚」的 cell 一律不进 §12.2 主榜。
 
 **English.** Ultra-short horizons carry the densest signal but also the harshest cost stack (T+1, stamp duty, holding-period-tiered dividend tax — weekly top-K rebalancing sits squarely in the 20% tier). Every future cell report must carry annualized two-sided turnover and cost-adjusted metrics; cells that look good on IC but lose net of cost stay off the §12.2 master ranking.
+
+**实现 (2026-07-17)**：`scripts/p3/master_lib.py` — `COST_SPEC_V1` / `daily_topk_replacement` / `cost_metric_block`；`kill_criteria_verdict` 增加 `cost_key` 第三条件（net-of-cost top-K 超额不得劣于 base，否则该窗口不算 WIN）。`master_ensemble_eval.py` 的 verdict 已默认启用。/ Implemented in `master_lib.py` (`COST_SPEC_V1`, `cost_metric_block`) and wired into `kill_criteria_verdict` as a third per-window condition; `master_ensemble_eval.py` enables it by default.
 
 ### 12.6 (deprecated content kept for git history)
 

--- a/scripts/p3/master_ensemble_eval.py
+++ b/scripts/p3/master_ensemble_eval.py
@@ -12,13 +12,30 @@ The blend never replaces the base. A KEEP means "MASTER earns a weight in the
 production rank blend"; a KILL means the experiment stops (Finding-style
 discipline: negative results get recorded, not retried with shifted goalposts).
 
+Cost discipline (§12.7d): every metric block is merged with
+``master_lib.cost_metric_block`` (annualized two-sided turnover + top-k T+1
+excess net of COST_SPEC_V1), and the verdict requires the blend to hold the
+net-of-cost excess in addition to IC / proximity — an IC win that loses net of
+trading costs is not a win.
+
+Pre-registered protocol (2026-07-17, before any 4070 run):
+  * eval windows: H1 + H2 + W3=2026-01-05:2026-06-30 (pass W3 via
+    ``--extra-window W3=2026-01-05:2026-06-30``; 2-window verdicts degenerate
+    to 2/2 and are logged with a warning)
+  * seeds: 42, 43, 44 — pass all three prediction parquets via repeated
+    ``--master-preds``; they are rank-averaged into ONE master score column
+    before blending (seed-ensemble, Phase 18 discipline)
+
 Usage::
 
     python scripts/p3/master_ensemble_eval.py \
         --master-preds runs/master_lite/d64_L8_seed42/predictions.parquet \
+        --master-preds runs/master_lite/d64_L8_seed43/predictions.parquet \
+        --master-preds runs/master_lite/d64_L8_seed44/predictions.parquet \
         --base-preds runs/sl_path5_long/best/predictions.parquet \
         --bundle data/p3_4070_long \
-        --out runs/master_lite/d64_L8_seed42/ensemble
+        --extra-window W3=2026-01-05:2026-06-30 \
+        --out runs/master_lite/d64_L8/ensemble
 """
 
 from __future__ import annotations
@@ -34,7 +51,11 @@ import polars as pl
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from p3.master_lib import blend_rank_scores, kill_criteria_verdict
+from p3.master_lib import (
+    blend_rank_scores,
+    cost_metric_block,
+    kill_criteria_verdict,
+)
 from p3.path1_eval import H1, H2, evaluate
 
 logger = logging.getLogger(__name__)
@@ -61,7 +82,13 @@ def main(argv: list[str] | None = None) -> int:
     ap = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
     )
-    ap.add_argument("--master-preds", required=True, type=Path)
+    ap.add_argument(
+        "--master-preds",
+        required=True,
+        type=Path,
+        action="append",
+        help="MASTER predictions parquet; repeat for multi-seed runs (rank-averaged)",
+    )
     ap.add_argument("--base-preds", required=True, type=Path)
     ap.add_argument("--bundle", default="data/p3_4070", type=Path)
     ap.add_argument("--out", required=True, type=Path)
@@ -81,8 +108,19 @@ def main(argv: list[str] | None = None) -> int:
     args.out.mkdir(parents=True, exist_ok=True)
 
     base = pl.read_parquet(args.base_preds).select(["trade_date", "ts_code", "score"])
-    master = pl.read_parquet(args.master_preds).select(["trade_date", "ts_code", "score"])
-    logger.info("base: %s rows | master: %s rows", f"{len(base):,}", f"{len(master):,}")
+    seeds = [
+        pl.read_parquet(p).select(["trade_date", "ts_code", "score"]) for p in args.master_preds
+    ]
+    # Multi-seed runs are rank-averaged into ONE master column before blending
+    # (equal weights). A single frame passes through unchanged.
+    master = seeds[0] if len(seeds) == 1 else blend_rank_scores(seeds, [1.0] * len(seeds))
+    logger.info(
+        "base: %s rows | master: %s rows (%d seed%s)",
+        f"{len(base):,}",
+        f"{len(master):,}",
+        len(seeds),
+        "" if len(seeds) == 1 else "s",
+    )
 
     target_y = pl.read_parquet(args.bundle / "target_y.parquet")
     realized = pl.read_parquet(args.bundle / "realized_returns.parquet").select(
@@ -93,10 +131,24 @@ def main(argv: list[str] | None = None) -> int:
     )
 
     windows = {"H1": H1, "H2": H2, **parse_windows(args.extra_window)}
+    if len(windows) < 3:
+        logger.warning(
+            "only %d eval windows: ceil(2/3 * %d) = %d, so the verdict degenerates to "
+            "all-windows-must-win; pre-registered protocol adds W3=2026-01-05:2026-06-30 "
+            "via --extra-window",
+            len(windows),
+            len(windows),
+            -(-2 * len(windows) // 3),
+        )
 
     def eval_all(preds: pl.DataFrame) -> dict[str, dict]:
+        # §12.7d: the standard metric block is merged with the turnover/cost
+        # block so the kill criteria can veto on net-of-cost excess.
         return {
-            name: evaluate(preds, target_y, realized, market, w, args.top_k)
+            name: {
+                **evaluate(preds, target_y, realized, market, w, args.top_k),
+                **cost_metric_block(preds, realized, market, w, args.top_k),
+            }
             for name, w in windows.items()
         }
 
@@ -118,20 +170,42 @@ def main(argv: list[str] | None = None) -> int:
 
     best_key = max(blend_metrics, key=lambda k: mean_ic(blend_metrics[k]))
     results["best_blend"] = best_key
-    results["kill_criteria"] = kill_criteria_verdict(results["base"], blend_metrics[best_key])
+    results["n_seeds"] = len(seeds)
+    # Self-documenting protocol flag: a verdict produced off-protocol (fewer
+    # than 3 windows or 3 seeds) is dev-grade and must not enter README §12.2.
+    results["protocol_ok"] = len(windows) >= 3 and len(seeds) >= 3
+    if not results["protocol_ok"]:
+        logger.warning(
+            "OFF-PROTOCOL RUN (windows=%d, seeds=%d; protocol needs >=3 of each): "
+            "verdict is dev-grade, do not record it as the pre-registered result",
+            len(windows),
+            len(seeds),
+        )
+    results["kill_criteria"] = kill_criteria_verdict(
+        results["base"],
+        blend_metrics[best_key],
+        cost_key="net_mean_topk_excess_t1",
+    )
 
     out_path = args.out / "ensemble_verdict.json"
     out_path.write_text(json.dumps(results, indent=2, default=str))
 
-    header = f"{'window':<10}{'base IC':>10}{'master IC':>11}{best_key + ' IC':>16}"
+    header = (
+        f"{'window':<10}{'base IC':>10}{'master IC':>11}{best_key + ' IC':>16}"
+        f"{'base net':>11}{'blend net':>11}{'blend t/o':>11}"
+    )
     logger.info("%s", header)
     for name in windows:
+        blend_w = blend_metrics[best_key][name]
         logger.info(
-            "%-10s%+10.4f%+11.4f%+16.4f",
+            "%-10s%+10.4f%+11.4f%+16.4f%+11.4f%+11.4f%11.1f",
             name,
             results["base"][name]["spearman"],
             results["master"][name]["spearman"],
-            blend_metrics[best_key][name]["spearman"],
+            blend_w["spearman"],
+            results["base"][name]["net_mean_topk_excess_t1"],
+            blend_w["net_mean_topk_excess_t1"],
+            blend_w["annualized_two_sided_turnover"],
         )
     verdict = results["kill_criteria"]
     logger.info(

--- a/scripts/p3/master_lib.py
+++ b/scripts/p3/master_lib.py
@@ -191,6 +191,131 @@ def blend_rank_scores(
 
 
 # =============================================================================
+# Cost model (README §12.7d — cost as a first-class citizen)
+# =============================================================================
+
+# Pre-registered cost spec v1 for daily top-K rebalancing on the A-share main
+# board. Dividend tax note: the exact per-lot FIFO holding-period tiering
+# (rqalpha `_pay_dividend_tax`) needs dividend-event data our bundles do not
+# carry; v1 pre-registers the approximation "~2 % average yield x 20 % tier
+# (holding <= 1 month, which daily top-K churn guarantees) = 40 bps/yr" applied
+# pro-rata per trading day. Changing any number here after looking at results
+# voids the verdict — bump to a COST_SPEC_V2 and rerun instead.
+COST_SPEC_V1: dict = {
+    "commission_bps_per_side": 2.5,
+    "stamp_duty_bps_sell": 5.0,
+    "slippage_bps_per_side": 10.0,
+    "dividend_tax_drag_bps_annual": 40.0,
+    "trading_days_per_year": 243,
+}
+
+
+def daily_topk_replacement(preds: pl.DataFrame, top_k: int) -> float:
+    """Mean fraction of the top-k basket replaced between consecutive dates.
+
+    ``preds`` needs (trade_date, ts_code, score). For each adjacent date pair
+    the replaced fraction is ``1 - |A ∩ B| / min(|A|, |B|)`` (the min guards
+    days that have fewer than ``top_k`` scored names). Ties on score break by
+    ``ts_code`` so basket membership is deterministic across input row order
+    and polars versions. Returns 0.0 with fewer than two dates
+    (degenerate-input convention, same as ``daily_rank_ic``).
+    """
+    topk = (
+        preds.sort(["trade_date", "score", "ts_code"], descending=[False, True, False])
+        .group_by("trade_date", maintain_order=True)
+        .head(top_k)
+    )
+    days = topk.partition_by("trade_date", maintain_order=True)
+    if len(days) < 2:
+        return 0.0
+    fracs: list[float] = []
+    prev = set(days[0]["ts_code"].to_list())
+    for day in days[1:]:
+        cur = set(day["ts_code"].to_list())
+        denom = max(1, min(len(prev), len(cur)))
+        fracs.append(1.0 - len(prev & cur) / denom)
+        prev = cur
+    return float(np.mean(fracs))
+
+
+def cost_drag_daily(replaced_frac: float, spec: dict = COST_SPEC_V1) -> float:
+    """Daily return drag (fraction) of running the top-k basket.
+
+    A replaced slot pays a full round trip: sell the outgoing name
+    (commission + stamp duty + slippage) and buy the incoming one
+    (commission + slippage). The dividend-tax drag accrues pro-rata daily
+    regardless of churn (holding at all incurs it under the v1 approximation).
+    """
+    round_trip = (
+        2 * spec["commission_bps_per_side"]
+        + spec["stamp_duty_bps_sell"]
+        + 2 * spec["slippage_bps_per_side"]
+    ) / 1e4
+    dividend_daily = spec["dividend_tax_drag_bps_annual"] / 1e4 / spec["trading_days_per_year"]
+    return replaced_frac * round_trip + dividend_daily
+
+
+def cost_metric_block(
+    preds: pl.DataFrame,
+    realized: pl.DataFrame,
+    market: pl.DataFrame,
+    window: tuple,
+    top_k: int = 50,
+    spec: dict = COST_SPEC_V1,
+) -> dict:
+    """Turnover + cost-adjusted top-k excess block (README §12.7d).
+
+    Args mirror ``path1_eval.evaluate``: ``realized`` has
+    (trade_date, ts_code, pct_chg_t_plus_1) where the row at the anchor date
+    already carries that anchor's T+1 return; ``market`` has
+    (trade_date, eq_weight_pct_chg_t_plus_1). Per-date top-k mean T+1 excess
+    is reported gross and net of ``cost_drag_daily``. Turnover is computed on
+    the same joined frame the gross metric uses, so basket membership and
+    return attribution agree.
+
+    Registered v1 simplification: turnover is pairwise between consecutive
+    dates, so the initial basket entry on day 1 of the window is not charged
+    (understates drag slightly on short windows; bump the spec version if
+    this is ever changed).
+    """
+    lo, hi = window
+    joined = (
+        preds.filter((pl.col("trade_date") >= lo) & (pl.col("trade_date") <= hi))
+        .join(realized, on=["trade_date", "ts_code"], how="inner")
+        .join(market, on="trade_date", how="inner")
+        .with_columns(
+            (pl.col("pct_chg_t_plus_1") - pl.col("eq_weight_pct_chg_t_plus_1")).alias("e1")
+        )
+        .drop_nulls(["score", "e1"])
+    )
+    n_dates = joined["trade_date"].n_unique() if len(joined) else 0
+    if n_dates == 0:
+        return {
+            "n_dates": 0,
+            "topk_daily_replaced_frac": 0.0,
+            "annualized_two_sided_turnover": 0.0,
+            "gross_mean_topk_excess_t1": 0.0,
+            "net_mean_topk_excess_t1": 0.0,
+            "cost_spec": dict(spec),
+        }
+    topk = (
+        joined.sort(["trade_date", "score", "ts_code"], descending=[False, True, False])
+        .group_by("trade_date", maintain_order=True)
+        .head(top_k)
+    )
+    gross = float(topk.group_by("trade_date").agg(pl.col("e1").mean().alias("m"))["m"].mean())
+    replaced = daily_topk_replacement(joined, top_k)
+    return {
+        "n_dates": n_dates,
+        "topk_daily_replaced_frac": replaced,
+        "annualized_two_sided_turnover": replaced * 2 * spec["trading_days_per_year"],
+        "gross_mean_topk_excess_t1": gross,
+        "net_mean_topk_excess_t1": gross - cost_drag_daily(replaced, spec),
+        "cost_spec": dict(spec),
+    }
+
+
+# =============================================================================
 # Pre-registered kill criteria (README §12.7)
 # =============================================================================
 
@@ -201,12 +326,16 @@ def kill_criteria_verdict(
     ic_key: str = "spearman",
     primary_key: str = "primary_mean_top50_proximity_excess",
     required_win_frac: float = 2 / 3,
+    cost_key: str | None = None,
 ) -> dict:
     """Pre-registered KEEP/KILL verdict for a treatment vs its baseline.
 
     Both args map window name -> metric block (the dicts produced by
-    ``p3.path1_eval.evaluate``). A window is a WIN when the treatment beats the
-    base on ``ic_key`` AND is not worse on ``primary_key``. Verdict is KEEP iff
+    ``p3.path1_eval.evaluate``, optionally merged with ``cost_metric_block``).
+    A window is a WIN when the treatment beats the base on ``ic_key`` AND is
+    not worse on ``primary_key`` AND — when ``cost_key`` is given — is not
+    worse on the cost-adjusted metric either (§12.7d: an IC win that loses
+    net of trading costs is not a win). Verdict is KEEP iff
     wins >= ceil(required_win_frac * n_windows), else KILL.
 
     The criteria are registered BEFORE the experiment runs (this function is the
@@ -223,14 +352,21 @@ def kill_criteria_verdict(
         ic_win = t[ic_key] > b[ic_key]
         primary_ok = t[primary_key] >= b[primary_key]
         win = bool(ic_win and primary_ok)
-        wins += win
-        detail[name] = {
-            "win": win,
+        entry = {
             "ic_base": b[ic_key],
             "ic_treatment": t[ic_key],
             "primary_base": b[primary_key],
             "primary_treatment": t[primary_key],
         }
+        if cost_key is not None:
+            cost_ok = t[cost_key] >= b[cost_key]
+            win = win and cost_ok
+            entry["cost_base"] = b[cost_key]
+            entry["cost_treatment"] = t[cost_key]
+            entry["cost_ok"] = cost_ok
+        entry["win"] = win
+        wins += win
+        detail[name] = entry
     required = math.ceil(required_win_frac * len(windows))
     return {
         "verdict": "KEEP" if wins >= required else "KILL",
@@ -239,5 +375,6 @@ def kill_criteria_verdict(
         "n_windows": len(windows),
         "ic_key": ic_key,
         "primary_key": primary_key,
+        "cost_key": cost_key,
         "windows": detail,
     }

--- a/scripts/p3/master_train.py
+++ b/scripts/p3/master_train.py
@@ -52,6 +52,7 @@ import json
 import logging
 import sys
 import time
+import warnings
 from pathlib import Path
 
 import numpy as np
@@ -60,6 +61,7 @@ import polars as pl
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from p3.master_lib import (
+    STD_FLOOR,
     build_sequence_windows,
     cs_zscore_panel,
     daily_rank_ic,
@@ -126,6 +128,40 @@ def densify(
     return x, y, dates, codes
 
 
+def masked_market_vector(x_anchor: np.ndarray, present_row: np.ndarray) -> np.ndarray:
+    """Cross-sectional mean feature vector over present stocks only.
+
+    After ``cs_zscore_panel`` absent stocks sit at exactly 0; averaging them in
+    shrinks the market-state vector toward 0 in proportion to how many names
+    are absent that day. Falls back to the all-rows mean when nothing is
+    present (degenerate warmup dates).
+    """
+    if present_row.any():
+        return x_anchor[present_row].mean(axis=0)
+    return x_anchor.mean(axis=0)
+
+
+def zscore_labels_per_date(y: np.ndarray, present: np.ndarray) -> np.ndarray:
+    """Z-score labels per date over present stocks; absent cells left untouched.
+
+    Raw proximity labels keep their cross-sectional dispersion, letting
+    high-dispersion dates dominate the MSE loss; per-date normalization makes
+    every anchor date contribute comparably (scores are only consumed as a
+    within-date ranking downstream). Std is floored at ``STD_FLOOR`` so a
+    constant cross-section maps to 0 instead of exploding.
+    """
+    masked = np.where(present, y, np.nan)
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message="Mean of empty slice")
+        warnings.filterwarnings("ignore", message="Degrees of freedom <= 0")
+        mean = np.nanmean(masked, axis=1, keepdims=True)
+        std = np.nanstd(masked, axis=1, keepdims=True)
+    mean = np.nan_to_num(mean, nan=0.0)
+    std = np.maximum(np.nan_to_num(std, nan=0.0), STD_FLOOR)
+    z = (y - mean) / std
+    return np.where(present, z, y).astype(np.float32)
+
+
 # ------------------------------------------------------------------ #
 # Model (torch imported lazily so --help works on CPU-only boxes)
 # ------------------------------------------------------------------ #
@@ -159,12 +195,19 @@ def build_model(n_factors: int, d_model: int, n_heads: int, dropout: float):
             )
             self.head = nn.Linear(d_model, 1)
 
-        def forward(self, x, market):
-            # x: [N, L, F] one anchor date; market: [F] cross-section mean at anchor.
+        def forward(self, x, market, pad_mask=None):
+            # x: [N, L, F] one anchor date; market: [F] present-stock mean at
+            # anchor; pad_mask: [N] bool, True = absent stock (excluded from
+            # cross-stock attention keys, src_key_padding_mask convention).
+            if pad_mask is not None and bool(pad_mask.all()):
+                pad_mask = None  # degenerate all-absent date: avoid NaN attention
             g = self.gate(market)  # [F] market-guided feature gate
             h = self.proj(x * g)  # [N, L, d]
             h = self.temporal(h)[:, -1, :]  # [N, d] last-step summary
-            h = self.cross(h.unsqueeze(0)).squeeze(0)  # attention across stocks
+            h = self.cross(
+                h.unsqueeze(0),
+                src_key_padding_mask=None if pad_mask is None else pad_mask.unsqueeze(0),
+            ).squeeze(0)  # attention across present stocks
             return self.head(h).squeeze(-1)  # [N]
 
     return MasterLite()
@@ -209,6 +252,13 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     p.add_argument("--val-frac", type=float, default=0.15)
     p.add_argument("--embargo-days", type=int, default=30)
     p.add_argument("--seed", type=int, default=42)
+    p.add_argument(
+        "--label-norm",
+        choices=("zscore", "none"),
+        default="zscore",
+        help="per-date cross-sectional z-score of the training labels (loss only; "
+        "val IC and eval blocks always use raw y)",
+    )
     p.add_argument("--device", default="cuda")
     p.add_argument("--no-amp", action="store_true", help="disable bf16 autocast")
     p.add_argument(
@@ -258,7 +308,8 @@ def main(argv: list[str] | None = None) -> int:
     feat_present = ~np.isnan(x).all(axis=2)  # [D, N] stock has any feature this date
     x = cs_zscore_panel(x)
     present = ~np.isnan(y)  # [D, N] stock has a label at this date
-    y = np.nan_to_num(y, nan=0.0)
+    y_raw = np.nan_to_num(y, nan=0.0)  # reporting/eval always sees raw labels
+    y = zscore_labels_per_date(y_raw, present) if args.label_norm == "zscore" else y_raw
     logger.info("dense panel: D=%d N=%d F=%d (%.0fs)", *x.shape, time.time() - t0)
 
     windows = build_sequence_windows(len(dates), args.seq_len)
@@ -289,10 +340,12 @@ def main(argv: list[str] | None = None) -> int:
 
     def forward_date(i: int):
         w = windows[i]
+        anchor = w[-1]
         xb = x_t[w].permute(1, 0, 2).to(device, non_blocking=True)  # [N, L, F]
-        market = xb[:, -1, :].mean(dim=0)  # [F]
+        market = torch.from_numpy(masked_market_vector(x[anchor], feat_present[anchor])).to(device)
+        pad = torch.from_numpy(~(feat_present[anchor] | present[anchor])).to(device)
         with torch.autocast(device_type=device.type, dtype=torch.bfloat16, enabled=use_amp):
-            return model(xb, market)
+            return model(xb, market, pad_mask=pad)
 
     def val_ic() -> float:
         model.eval()
@@ -307,7 +360,7 @@ def main(argv: list[str] | None = None) -> int:
                             "trade_date": [anchor_dates[i]] * int(mask.sum()),
                             "ts_code": [codes[j] for j in np.flatnonzero(mask)],
                             "score": scores[mask],
-                            "actual_y": y[windows[i][-1]][mask],
+                            "actual_y": y_raw[windows[i][-1]][mask],
                         }
                     )
                 )

--- a/tests/p3/test_master_ensemble_eval.py
+++ b/tests/p3/test_master_ensemble_eval.py
@@ -1,0 +1,126 @@
+"""Integration tests for scripts/p3/master_ensemble_eval.py (CLI wiring).
+
+Runs main() against a tiny synthetic bundle in tmp_path and asserts the §12.7d
+contract: every metric block carries the turnover/cost fields, the verdict is
+rendered with the cost veto enabled, and multi-seed --master-preds inputs are
+rank-averaged into one master column.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+from pathlib import Path
+
+import numpy as np
+import polars as pl
+import pytest
+from p3.master_ensemble_eval import main, parse_windows
+
+N_STOCKS = 10
+N_DATES = 12
+CODES = [f"SYN{i:03d}" for i in range(N_STOCKS)]
+# January dates: outside H1/H2 so those default windows stay empty in tests
+DATES = [dt.date(2025, 1, 6) + dt.timedelta(days=i) for i in range(N_DATES)]
+ANCHORS = DATES[:8]  # anchors need 2 later realized dates for e2/e3
+WINDOW_SPEC = "W=2025-01-01:2025-01-31"
+
+
+def _write_bundle(bundle: Path) -> None:
+    bundle.mkdir(parents=True)
+    rng = np.random.default_rng(7)
+    long_rows = {
+        "trade_date": [d for d in DATES for _ in CODES],
+        "ts_code": CODES * N_DATES,
+    }
+    pl.DataFrame({**long_rows, "y": rng.normal(0.0, 0.02, N_DATES * N_STOCKS)}).write_parquet(
+        bundle / "target_y.parquet"
+    )
+    pl.DataFrame(
+        {**long_rows, "pct_chg_t_plus_1": rng.normal(0.0, 0.02, N_DATES * N_STOCKS)}
+    ).write_parquet(bundle / "realized_returns.parquet")
+    pl.DataFrame(
+        {"trade_date": DATES, "eq_weight_pct_chg_t_plus_1": rng.normal(0.0, 0.005, N_DATES)}
+    ).write_parquet(bundle / "market_returns.parquet")
+
+
+def _write_preds(path: Path, seed: int) -> None:
+    rng = np.random.default_rng(seed)
+    pl.DataFrame(
+        {
+            "trade_date": [d for d in ANCHORS for _ in CODES],
+            "ts_code": CODES * len(ANCHORS),
+            "score": rng.normal(0.0, 1.0, len(ANCHORS) * N_STOCKS),
+        }
+    ).write_parquet(path)
+
+
+@pytest.fixture()
+def bundle_and_preds(tmp_path: Path) -> dict[str, Path]:
+    bundle = tmp_path / "bundle"
+    _write_bundle(bundle)
+    paths = {"bundle": bundle, "out": tmp_path / "out"}
+    for name, seed in (("base", 1), ("m42", 42), ("m43", 43)):
+        paths[name] = tmp_path / f"{name}.parquet"
+        _write_preds(paths[name], seed)
+    return paths
+
+
+def _run(paths: dict[str, Path], master_flags: list[str]) -> dict:
+    argv = [
+        *master_flags,
+        "--base-preds",
+        str(paths["base"]),
+        "--bundle",
+        str(paths["bundle"]),
+        "--out",
+        str(paths["out"]),
+        "--top-k",
+        "3",
+        "--extra-window",
+        WINDOW_SPEC,
+    ]
+    assert main(argv) == 0
+    return json.loads((paths["out"] / "ensemble_verdict.json").read_text())
+
+
+def test_verdict_json_carries_cost_fields_and_cost_veto(bundle_and_preds):
+    results = _run(bundle_and_preds, ["--master-preds", str(bundle_and_preds["m42"])])
+    w_block = results["base"]["W"]
+    for key in (
+        "spearman",
+        "primary_mean_top50_proximity_excess",
+        "topk_daily_replaced_frac",
+        "annualized_two_sided_turnover",
+        "gross_mean_topk_excess_t1",
+        "net_mean_topk_excess_t1",
+    ):
+        assert key in w_block, f"missing {key} in merged metric block"
+    # gross data exists in W and costs are strictly positive -> net < gross
+    assert w_block["net_mean_topk_excess_t1"] < w_block["gross_mean_topk_excess_t1"]
+    verdict = results["kill_criteria"]
+    assert verdict["cost_key"] == "net_mean_topk_excess_t1"
+    assert verdict["verdict"] in ("KEEP", "KILL")
+    assert results["n_seeds"] == 1
+    # windows H1/H2 (empty synthetic data) still produce inert blocks, no crash
+    assert results["base"]["H1"]["n_rows"] == 0
+
+
+def test_multi_seed_masters_are_rank_averaged(bundle_and_preds):
+    paths = bundle_and_preds
+    results = _run(
+        paths,
+        ["--master-preds", str(paths["m42"]), "--master-preds", str(paths["m43"])],
+    )
+    assert results["n_seeds"] == 2
+    # the ensembled master is a real average: its W-window IC differs from
+    # either single seed's unless they tie (vanishingly unlikely under rng)
+    single = _run(paths, ["--master-preds", str(paths["m42"])])
+    assert results["master"]["W"]["spearman"] != single["master"]["W"]["spearman"]
+
+
+def test_parse_windows_roundtrip_and_rejects_garbage():
+    parsed = parse_windows(["W3=2026-01-05:2026-06-30"])
+    assert parsed["W3"] == (dt.date(2026, 1, 5), dt.date(2026, 6, 30))
+    with pytest.raises(SystemExit, match="bad --extra-window"):
+        parse_windows(["W3=2026-01-05"])

--- a/tests/p3/test_master_lib.py
+++ b/tests/p3/test_master_lib.py
@@ -14,11 +14,15 @@ import numpy as np
 import polars as pl
 import pytest
 from p3.master_lib import (
+    COST_SPEC_V1,
     ZSCORE_CLIP,
     blend_rank_scores,
     build_sequence_windows,
+    cost_drag_daily,
+    cost_metric_block,
     cs_zscore_panel,
     daily_rank_ic,
+    daily_topk_replacement,
     kill_criteria_verdict,
     train_val_split_with_embargo,
 )
@@ -238,3 +242,182 @@ def test_kill_verdict_two_windows_requires_both():
     base = {"H1": _metrics(0.03, 0.010), "H2": _metrics(0.02, 0.008)}
     treat = {"H1": _metrics(0.05, 0.011), "H2": _metrics(0.01, 0.009)}
     assert kill_criteria_verdict(base, treat)["verdict"] == "KILL"
+
+
+# =============================================================================
+# daily_topk_replacement / cost_drag_daily / cost_metric_block (README §12.7d)
+# =============================================================================
+
+
+def test_topk_replacement_identical_membership_is_zero():
+    d1, d2 = dt.date(2025, 6, 2), dt.date(2025, 6, 3)
+    preds = _score_frame(d1, {"c1": 3.0, "c2": 2.0, "c3": 1.0}).vstack(
+        _score_frame(d2, {"c1": 30.0, "c2": 20.0, "c3": 1.0})
+    )
+    assert daily_topk_replacement(preds, top_k=2) == pytest.approx(0.0)
+
+
+def test_topk_replacement_full_and_half_churn():
+    d1, d2, d3 = dt.date(2025, 6, 2), dt.date(2025, 6, 3), dt.date(2025, 6, 4)
+    scores = {
+        # day1 top-2 = {c1, c2}; day2 top-2 = {c3, c4} (full churn);
+        # day3 top-2 = {c3, c1} (half churn vs day2)
+        d1: {"c1": 4.0, "c2": 3.0, "c3": 2.0, "c4": 1.0},
+        d2: {"c1": 1.0, "c2": 2.0, "c3": 4.0, "c4": 3.0},
+        d3: {"c1": 3.0, "c2": 1.0, "c3": 4.0, "c4": 2.0},
+    }
+    preds = pl.concat([_score_frame(d, s) for d, s in scores.items()])
+    # pairs: (d1,d2) -> 1.0 replaced; (d2,d3) -> 0.5 replaced; mean = 0.75
+    assert daily_topk_replacement(preds, top_k=2) == pytest.approx(0.75)
+
+
+def test_topk_replacement_single_day_is_zero():
+    preds = _score_frame(dt.date(2025, 6, 2), {"c1": 1.0, "c2": 2.0})
+    assert daily_topk_replacement(preds, top_k=2) == 0.0
+
+
+def test_cost_drag_daily_arithmetic():
+    spec = {
+        "commission_bps_per_side": 2.5,
+        "stamp_duty_bps_sell": 5.0,
+        "slippage_bps_per_side": 10.0,
+        "dividend_tax_drag_bps_annual": 40.0,
+        "trading_days_per_year": 243,
+    }
+    # per replaced slot: sell (2.5 + 5 + 10) + buy (2.5 + 10) = 30 bps
+    # drag = 0.5 * 30bps + 40bps / 243
+    expected = 0.5 * 30e-4 + 40e-4 / 243
+    assert cost_drag_daily(0.5, spec) == pytest.approx(expected)
+    # zero churn still pays the dividend-tax drag
+    assert cost_drag_daily(0.0, spec) == pytest.approx(40e-4 / 243)
+
+
+def test_cost_spec_v1_is_registered():
+    for key in (
+        "commission_bps_per_side",
+        "stamp_duty_bps_sell",
+        "slippage_bps_per_side",
+        "dividend_tax_drag_bps_annual",
+        "trading_days_per_year",
+    ):
+        assert key in COST_SPEC_V1
+
+
+def _cost_fixture() -> tuple[pl.DataFrame, pl.DataFrame, pl.DataFrame]:
+    d1, d2 = dt.date(2025, 7, 1), dt.date(2025, 7, 2)
+    preds = _score_frame(d1, {"c1": 2.0, "c2": 1.0}).vstack(
+        _score_frame(d2, {"c1": 1.0, "c2": 2.0})  # top-1 flips c1 -> c2: full churn
+    )
+    realized = pl.DataFrame(
+        {
+            "trade_date": [d1, d1, d2, d2],
+            "ts_code": ["c1", "c2", "c1", "c2"],
+            "pct_chg_t_plus_1": [0.02, 0.00, 0.00, 0.03],
+        }
+    )
+    market = pl.DataFrame(
+        {
+            "trade_date": [d1, d2],
+            "eq_weight_pct_chg_t_plus_1": [0.01, 0.01],
+        }
+    )
+    return preds, realized, market
+
+
+def test_cost_metric_block_gross_net_and_turnover():
+    preds, realized, market = _cost_fixture()
+    block = cost_metric_block(
+        preds, realized, market, window=(dt.date(2025, 7, 1), dt.date(2025, 7, 31)), top_k=1
+    )
+    # top-1: d1 -> c1 e1 = 0.02 - 0.01; d2 -> c2 e1 = 0.03 - 0.01; gross mean = 0.015
+    assert block["gross_mean_topk_excess_t1"] == pytest.approx(0.015)
+    assert block["topk_daily_replaced_frac"] == pytest.approx(1.0)
+    spec = COST_SPEC_V1
+    days = spec["trading_days_per_year"]
+    assert block["annualized_two_sided_turnover"] == pytest.approx(1.0 * 2 * days)
+    assert block["net_mean_topk_excess_t1"] == pytest.approx(0.015 - cost_drag_daily(1.0, spec))
+    assert block["cost_spec"] == spec
+
+
+def test_cost_metric_block_respects_window():
+    preds, realized, market = _cost_fixture()
+    block = cost_metric_block(
+        preds, realized, market, window=(dt.date(2025, 8, 1), dt.date(2025, 8, 31)), top_k=1
+    )
+    assert block["n_dates"] == 0
+    assert block["gross_mean_topk_excess_t1"] == 0.0
+    assert block["net_mean_topk_excess_t1"] == 0.0
+
+
+# =============================================================================
+# kill_criteria_verdict — cost-adjusted third condition (README §12.7d)
+# =============================================================================
+
+
+def _metrics_cost(ic: float, primary: float, net: float) -> dict:
+    return {
+        "spearman": ic,
+        "primary_mean_top50_proximity_excess": primary,
+        "net_mean_topk_excess_t1": net,
+    }
+
+
+def test_kill_verdict_cost_key_vetoes_ic_win():
+    # IC and primary both improve, but net-of-cost excess degrades -> not a win
+    base = {
+        "H1": _metrics_cost(0.03, 0.010, 0.0050),
+        "H2": _metrics_cost(0.02, 0.008, 0.0040),
+    }
+    treat = {
+        "H1": _metrics_cost(0.05, 0.011, 0.0020),
+        "H2": _metrics_cost(0.04, 0.009, 0.0010),
+    }
+    v = kill_criteria_verdict(base, treat, cost_key="net_mean_topk_excess_t1")
+    assert v["verdict"] == "KILL"
+    assert v["wins"] == 0
+    assert v["windows"]["H1"]["cost_base"] == pytest.approx(0.0050)
+    assert v["windows"]["H1"]["cost_treatment"] == pytest.approx(0.0020)
+
+
+def test_kill_verdict_cost_key_keep_when_net_holds():
+    base = {
+        "H1": _metrics_cost(0.03, 0.010, 0.0050),
+        "H2": _metrics_cost(0.02, 0.008, 0.0040),
+    }
+    treat = {
+        "H1": _metrics_cost(0.05, 0.011, 0.0055),
+        "H2": _metrics_cost(0.04, 0.009, 0.0040),
+    }
+    v = kill_criteria_verdict(base, treat, cost_key="net_mean_topk_excess_t1")
+    assert v["verdict"] == "KEEP"
+    assert v["wins"] == 2
+    assert v["cost_key"] == "net_mean_topk_excess_t1"
+
+
+def test_kill_verdict_without_cost_key_ignores_cost_fields():
+    # default (cost_key=None) must keep pre-existing behavior byte-compatible
+    base = {"H1": _metrics_cost(0.03, 0.010, 0.005)}
+    treat = {"H1": _metrics_cost(0.05, 0.011, 0.001)}
+    v = kill_criteria_verdict(base, treat)
+    assert v["verdict"] == "KEEP"
+    assert "cost_base" not in v["windows"]["H1"]
+
+
+def test_cost_spec_v1_numerics_are_pinned():
+    # Pre-registration means these literals are frozen: a change here without
+    # bumping to COST_SPEC_V2 voids every verdict produced under v1.
+    assert COST_SPEC_V1 == {
+        "commission_bps_per_side": 2.5,
+        "stamp_duty_bps_sell": 5.0,
+        "slippage_bps_per_side": 10.0,
+        "dividend_tax_drag_bps_annual": 40.0,
+        "trading_days_per_year": 243,
+    }
+
+
+def test_topk_replacement_ties_break_deterministically():
+    d1, d2 = dt.date(2025, 6, 2), dt.date(2025, 6, 3)
+    # all scores tie; ts_code tie-break keeps the same top-2 both days
+    tied = {"c3": 1.0, "c1": 1.0, "c2": 1.0}
+    preds = _score_frame(d1, tied).vstack(_score_frame(d2, tied))
+    assert daily_topk_replacement(preds, top_k=2) == pytest.approx(0.0)

--- a/tests/p3/test_master_train_model.py
+++ b/tests/p3/test_master_train_model.py
@@ -1,0 +1,129 @@
+"""Tests for the MASTER-lite model-layer fixes in scripts/p3/master_train.py.
+
+Pure-numpy helpers (masked market vector, per-date label z-score) run anywhere;
+model-forward tests need torch and skip on CPU-only boxes without it (they run
+on the 4070 as part of the bring-up).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from p3.master_train import masked_market_vector, zscore_labels_per_date
+
+# =============================================================================
+# masked_market_vector
+# =============================================================================
+
+
+def test_market_vector_ignores_absent_zero_rows():
+    # 2 present stocks with mean 2.0; 2 absent stocks sitting at 0 after the
+    # NaN->0 fill would dilute the naive mean to 1.0
+    x_anchor = np.array([[1.0], [3.0], [0.0], [0.0]], dtype=np.float32)
+    present = np.array([True, True, False, False])
+    naive = x_anchor.mean(axis=0)
+    masked = masked_market_vector(x_anchor, present)
+    np.testing.assert_allclose(naive, [1.0])
+    np.testing.assert_allclose(masked, [2.0])
+
+
+def test_market_vector_all_absent_falls_back_to_full_mean():
+    x_anchor = np.array([[1.0, 2.0], [3.0, 4.0]], dtype=np.float32)
+    present = np.array([False, False])
+    np.testing.assert_allclose(masked_market_vector(x_anchor, present), [2.0, 3.0])
+
+
+def test_market_vector_dtype_and_shape():
+    x_anchor = np.ones((5, 3), dtype=np.float32)
+    out = masked_market_vector(x_anchor, np.ones(5, dtype=bool))
+    assert out.shape == (3,) and out.dtype == np.float32
+
+
+# =============================================================================
+# zscore_labels_per_date
+# =============================================================================
+
+
+def test_label_zscore_normalizes_per_date_over_present():
+    y = np.array([[1.0, 2.0, 3.0, 0.0], [10.0, 20.0, 30.0, 0.0]], dtype=np.float32)
+    present = np.array([[True, True, True, False]] * 2)
+    z = zscore_labels_per_date(y, present)
+    for d in range(2):
+        vals = z[d][present[d]]
+        np.testing.assert_allclose(vals.mean(), 0.0, atol=1e-6)
+        np.testing.assert_allclose(vals.std(), 1.0, atol=1e-5)
+
+
+def test_label_zscore_leaves_absent_cells_untouched():
+    y = np.array([[1.0, 2.0, 7.5]], dtype=np.float32)
+    present = np.array([[True, True, False]])
+    z = zscore_labels_per_date(y, present)
+    assert z[0, 2] == pytest.approx(7.5)
+
+
+def test_label_zscore_constant_date_does_not_explode():
+    y = np.full((1, 4), 0.02, dtype=np.float32)
+    present = np.ones((1, 4), dtype=bool)
+    z = zscore_labels_per_date(y, present)
+    assert np.all(np.isfinite(z))
+    np.testing.assert_allclose(z[0], 0.0, atol=1e-5)
+
+
+def test_label_zscore_all_absent_date_is_inert():
+    y = np.array([[0.5, -0.5]], dtype=np.float32)
+    present = np.zeros((1, 2), dtype=bool)
+    z = zscore_labels_per_date(y, present)
+    np.testing.assert_allclose(z[0], [0.5, -0.5])
+
+
+# =============================================================================
+# MasterLite forward + padding mask (torch required)
+# =============================================================================
+
+
+def _tiny_model_and_input():
+    torch = pytest.importorskip("torch")
+    from p3.master_train import build_model
+
+    torch.manual_seed(0)
+    n, length, f, d = 6, 3, 4, 8
+    model = build_model(n_factors=f, d_model=d, n_heads=2, dropout=0.0)
+    model.eval()
+    x = torch.randn(n, length, f)
+    market = torch.randn(f)
+    return torch, model, x, market
+
+
+def test_forward_without_mask_returns_finite_scores():
+    torch, model, x, market = _tiny_model_and_input()
+    with torch.no_grad():
+        scores = model(x, market)
+    assert scores.shape == (x.shape[0],)
+    assert torch.isfinite(scores).all()
+
+
+def test_pad_mask_isolates_present_rows_from_absent_rows():
+    torch, model, x, market = _tiny_model_and_input()
+    pad = torch.zeros(x.shape[0], dtype=torch.bool)
+    pad[-1] = True  # last stock is absent
+    x_mut = x.clone()
+    x_mut[-1] += 5.0  # perturb ONLY the absent stock
+
+    with torch.no_grad():
+        base = model(x, market, pad_mask=pad)
+        masked_mut = model(x_mut, market, pad_mask=pad)
+        unmasked = model(x, market)
+        unmasked_mut = model(x_mut, market)
+
+    # with the mask, mutating the absent row cannot leak into present rows
+    torch.testing.assert_close(base[:-1], masked_mut[:-1])
+    # sanity: without the mask the same mutation DOES leak (mask is load-bearing)
+    assert not torch.allclose(unmasked[:-1], unmasked_mut[:-1])
+
+
+def test_all_absent_pad_mask_falls_back_to_no_mask():
+    torch, model, x, market = _tiny_model_and_input()
+    pad = torch.ones(x.shape[0], dtype=torch.bool)
+    with torch.no_grad():
+        scores = model(x, market, pad_mask=pad)
+    assert torch.isfinite(scores).all()


### PR DESCRIPTION
## Summary
- 4070 训练启动前锁定 KEEP/KILL 协议(TDD, tests green)
- 成本一等公民 (§12.7d): `master_lib` 新增 `COST_SPEC_V1`(佣金 2.5bps/边 + 印花税 5bps 卖方 + 冲击 10bps/边 + 红利税近似 40bps/年 pro-rata)、`daily_topk_replacement`(ts_code tie-break 确定性 membership)、`cost_metric_block`(年化双边换手 + gross/net top-K T+1 超额)
- `kill_criteria_verdict` 增加 `cost_key` 第三条件:IC 赢但 net-of-cost 输的窗口不算 WIN(向后兼容 `cost_key=None`)
- `master_ensemble_eval`: `--master-preds` 可重复(3 seed rank 平均后再 blend),预注册 `W3=2026-01-05:2026-06-30`,`protocol_ok` 自证字段(<3 窗或 <3 seed 的 verdict 标记为 dev-grade)
- `master_train` 模型层: `masked_market_vector`(市场向量不再被缺席股票的零行稀释)、cross-stock attention `src_key_padding_mask`(缺席股票退出注意力 key)、`--label-norm zscore` 默认开(per-date 标签标准化只进训练 loss,val IC / eval 恒用原始 y)
- 交叉评审: grok-4 read-only 复核,采纳 3 条(COST_SPEC 数值钉死 / tie-break / protocol_ok),驳回 2 条经核实的误报

## Why merge to main now
ledashi 4070 训练机通过 `git pull` 只跟踪 `main` 分支(见项目同步拓扑),这次的成本否决协议是 4070 启动训练前的强制门槛(commit message: "4070 训练启动前锁定 KEEP/KILL 协议")。协议留在 feature 分支上,4070 拉取到的仍是 5/17 的旧版 `master_lib.py`(没有 COST_SPEC_V1 / cost_key / masked_market_vector / label-norm zscore / protocol_ok),会导致 4070 用 off-protocol 版本跑出不受本协议约束的结果。

## Test plan
- [x] `uv run pytest tests/p3/test_master_lib.py tests/p3/test_master_ensemble_eval.py tests/p3/test_master_train_model.py -q` → 43 passed, 3 skipped(skip 项需要 torch,ECS 按项目红线不装,预期行为;ledashi 4070 上应全绿)
- [ ] CI (`ci.yml`) 绿灯后合并

Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)